### PR TITLE
[Add] 管理運営画面用のコントローラー・ルーティング・ビューファイルを作成する#21

### DIFF
--- a/app/controllers/operator/base_controller.rb
+++ b/app/controllers/operator/base_controller.rb
@@ -1,10 +1,11 @@
 class Operator::BaseController < ApplicationController
+  add_flash_types :success, :info, :warning, :danger
   layout 'operator/layouts/application'
   before_action :require_login
 
   private
 
   def not_authenticated
-    redirect_to operator_cat_in_path, alert: 'Please login first'
+    redirect_to root_path
   end
 end

--- a/app/controllers/operator/base_controller.rb
+++ b/app/controllers/operator/base_controller.rb
@@ -5,6 +5,6 @@ class Operator::BaseController < ApplicationController
   private
 
   def not_authenticated
-    redirect_to operator_login_path, alert: 'Please login first'
+    redirect_to operator_cat_in_path, alert: 'Please login first'
   end
 end

--- a/app/controllers/operator/boards_controller.rb
+++ b/app/controllers/operator/boards_controller.rb
@@ -1,0 +1,3 @@
+class Operator::BoardsController < Operator::BaseController
+  def index; end
+end

--- a/app/controllers/operator/operator_sessions_controller.rb
+++ b/app/controllers/operator/operator_sessions_controller.rb
@@ -7,7 +7,7 @@ class Operator::OperatorSessionsController < Operator::BaseController
     @operator = login(params[:email], params[:password])
 
     if @operator
-      redirect_to operator_boards_path
+      redirect_to operator_boards_path, success: 'キャットインしました。'
     else
       render :new
     end
@@ -15,6 +15,6 @@ class Operator::OperatorSessionsController < Operator::BaseController
 
   def destroy
     logout
-    redirect_to operator_cat_in_path
+    redirect_to operator_cat_in_path, success: 'キャットアウトしました。'
   end
 end

--- a/app/controllers/operator/operator_sessions_controller.rb
+++ b/app/controllers/operator/operator_sessions_controller.rb
@@ -7,8 +7,7 @@ class Operator::OperatorSessionsController < Operator::BaseController
     @operator = login(params[:email], params[:password])
 
     if @operator
-      # ログイン後の遷移先が作成された際にリダイレクト先を修正します。
-      redirect_to operator_cat_in_path
+      redirect_to operator_boards_path
     else
       render :new
     end

--- a/app/views/operator/layouts/application.html.slim
+++ b/app/views/operator/layouts/application.html.slim
@@ -10,4 +10,5 @@ html
     = javascript_pack_tag 'application'
   body
     = render 'operator/shared/navbar'
+    = render 'shared/flash_message'
     = yield

--- a/app/views/operator/shared/_navbar.html.slim
+++ b/app/views/operator/shared/_navbar.html.slim
@@ -6,7 +6,7 @@ nav.navbar.navbar-expand-md.navbar-dark.bg-secondary.fixed-top
     ul.navbar-nav.ps-3
       - if logged_in?
         li.nav-item
-          = link_to '#', class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
+          = link_to operator_boards_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
             icon.fas.fa-paw.me-2
             .guide-text
               | トップページ

--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,0 +1,3 @@
+- flash.each do |message_type, message|
+  div class="alert alert-#{message_type}"
+    = message

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,4 @@ ja:
         name: '名前'
         email: 'メールアドレス'
         password: 'パスワード'
+        role: '役割'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get    'cat_in',  to: 'operator_sessions#new'
     post   'cat_in',  to: 'operator_sessions#create'
     delete 'cat_out', to: 'operator_sessions#destroy'
+    resources :boards, only: %i[index]
   end
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
Issue #21 
ログイン後に表示される管理運営画面(トップページ)用のコントローラー・ルーティング・ビューファイルを作成します。

## 目的
ログイン成功時の遷移先を確定させます。

## 確認事項
・まだ何も表示できるものがないので、白紙画面が表示される状態にしてください。
・コントローラー名は「boards_controller」、アクションは「index」で実装してください。
・ログイン状態でナビバーに表示される「トップページ」は、本実装のページに飛ぶように実装してください。

＊ログイン＝キャットイン