### PR TITLE
[Add] Operatorモデルの単体テストを行う #22

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,3 +70,6 @@ Layout/CommentIndentation:
 Layout/LineLength:
   Exclude:
     - 'config/initializers/sorcery.rb'
+
+RSpec/ContextWording:
+  Enabled: false

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -2,11 +2,12 @@ class Operator < ApplicationRecord
   authenticates_with_sorcery!
   enum role: { operator: 0, guest: 1 }
 
-  validates :name,                    presence: true, length: { maximum: 255 }
+  validates :name,                    presence: true, length: { minimum: 2, maximum: 255 }
   validates :email,                   presence: true, uniqueness: true
-  validates :password,                length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :email,                   format: { with: /\A[a-z0-9_-]+@[a-z0-9_-]+[\\.][a-z0-9_-]+/ }
+  validates :password,                presence: true
+  validates :password,                length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password,                confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation,   presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :role,                    presence: true,
-                                      numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
+  validates :role,                    presence: true
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,5 +1,27 @@
 ja:
   activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+      models:
+        operator:
+          attributes:
+            name:
+              blank: 'が空白です'
+              too_short: 'が短すぎです'
+              too_long: 'が長すぎです'
+            email:
+              blank: 'が空白です'
+              invalid: 'が正しくありません'
+            password:
+              blank: 'が空白です'
+              too_short: 'が短すぎです'
+            password_confirmation:
+              blank: 'が空白です'
+              confirmation: 'が正しくありません'
+            role:
+              blank: 'が空白です'
+
     models:
       operator: 'オペレーター'
     attributes:
@@ -8,4 +30,11 @@ ja:
         name: '名前'
         email: 'メールアドレス'
         password: 'パスワード'
+        password_confirmation: 'パスワード(確認)'
         role: '役割'
+
+  enums:
+    operator:
+      role:
+        operator: '管理運営'
+        guest: 'ゲスト'

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :operator do
+    name { 'operator' }
+    email { 'operator@exampl.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    role { '0' }
+
+    trait :guest do
+      name { 'guest' }
+      email { 'guest@example.com' }
+      password { 'password' }
+      password_confirmation { 'password' }
+      role { '1' }
+    end
+  end
+end

--- a/spec/factories/operators.rb
+++ b/spec/factories/operators.rb
@@ -4,14 +4,14 @@ FactoryBot.define do
     email { 'operator@exampl.com' }
     password { 'password' }
     password_confirmation { 'password' }
-    role { '0' }
+    role { :operator }
 
     trait :guest do
       name { 'guest' }
       email { 'guest@example.com' }
       password { 'password' }
       password_confirmation { 'password' }
-      role { '1' }
+      role { :guest }
     end
   end
 end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe Operator, type: :model do
+  let(:operator) { create(:operator) }
+
+  describe '正常系テスト' do
+    context 'name' do
+      it '2つ以上の文字列が入力された場合、保存できる。' do
+      end
+
+      it '255以下の文字列が入力された場合、保存できる。' do
+      end
+    end
+
+    context 'email' do
+      it '@マークを含む文字列が入力された場合、保存できる。' do
+      end
+    end
+
+    context 'password' do
+      it '8つ以上の文字列が入力された場合、保存できる。' do
+      end
+    end
+
+    context 'role' do
+      it '0以上の値が入力された場合、保存できる。' do
+      end
+
+      it '1以下の値が入力された場合、保存できる。' do
+      end
+    end
+  end
+
+  describe '異常系テスト' do
+    context 'name' do
+      it '空の状態だと、保存できない。' do
+      end
+
+      it '1以下の文字列が入力された場合、保存できない。' do
+      end
+
+      it '256以上の文字列が入力された場合、保存できない。' do
+      end
+    end
+
+    context 'email' do
+      it '空の状態だと、保存できない。' do
+      end
+
+      it '@マークを含まない文字列が入力された場合、保存できない。' do
+      end
+
+      it '@マークの前に文字列が含まれなかった場合、保存できない。' do
+      end
+
+      it '@マークの後ろに文字列が含まれなかった場合、保存できない。' do
+      end
+    end
+
+    context 'password' do
+      it '空の状態だと、保存できない。' do
+      end
+
+      it '7つ以下の文字列が入力された場合、保存できない。' do
+      end
+    end
+
+    context 'password_confirmation' do
+      it '空の状態だと、保存できない。' do
+      end
+
+      it 'passwordと一致しない場合、保存できない。' do
+      end
+    end
+
+    context 'role' do
+      it '空の状態だと、保存できない。' do
+      end
+
+      it '2以上の値が入力された場合、保尊できない。' do
+      end
+    end
+  end
+end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -1,32 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe Operator, type: :model do
-  let(:operator) { create(:operator) }
+  let(:operator) { build(:operator) }
 
   describe '正常系テスト' do
+    context '全て有効な場合' do
+      it '保存できる。' do
+        expect(operator).to be_valid
+      end
+    end
+
     context 'name' do
       it '2つ以上の文字列が入力された場合、保存できる。' do
+        operator[:name] = 'aZ'
+        expect(operator).to be_valid
       end
 
       it '255以下の文字列が入力された場合、保存できる。' do
+        operator[:name] = 'a' * 255
+        expect(operator).to be_valid
       end
     end
 
     context 'email' do
       it '@マークを含む文字列が入力された場合、保存できる。' do
+        operator[:email] = 'sample@example.com'
+        expect(operator).to be_valid
       end
     end
 
     context 'password' do
       it '8つ以上の文字列が入力された場合、保存できる。' do
+        operator = build(:operator, password: 'a' * 8, password_confirmation: 'a' * 8)
+        expect(operator).to be_valid
       end
     end
 
     context 'role' do
       it '0以上の値が入力された場合、保存できる。' do
+        operator[:role] = 0
+        expect(operator).to be_valid
       end
 
       it '1以下の値が入力された場合、保存できる。' do
+        operator[:role] = 1
+        expect(operator).to be_valid
       end
     end
   end
@@ -34,50 +52,83 @@ RSpec.describe Operator, type: :model do
   describe '異常系テスト' do
     context 'name' do
       it '空の状態だと、保存できない。' do
+        operator = build(:operator, name: nil)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('名前 が空白です')
       end
 
       it '1以下の文字列が入力された場合、保存できない。' do
+        operator = build(:operator, name: 'a')
+        operator.valid?
+        expect(operator.errors.full_messages).to include('名前 が短すぎです')
       end
 
       it '256以上の文字列が入力された場合、保存できない。' do
+        operator = build(:operator, name: 'a' * 256)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('名前 が長すぎです')
       end
     end
 
     context 'email' do
       it '空の状態だと、保存できない。' do
+        operator = build(:operator, email: nil)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('メールアドレス が空白です')
       end
 
       it '@マークを含まない文字列が入力された場合、保存できない。' do
+        operator = build(:operator, email: 'operatorexampl.com')
+        operator.valid?
+        expect(operator.errors.full_messages).to include('メールアドレス が正しくありません')
       end
 
       it '@マークの前に文字列が含まれなかった場合、保存できない。' do
+        operator = build(:operator, email: '@exampl.com')
+        operator.valid?
+        expect(operator.errors.full_messages).to include('メールアドレス が正しくありません')
       end
 
       it '@マークの後ろに文字列が含まれなかった場合、保存できない。' do
+        operator = build(:operator, email: 'operator@.com')
+        operator.valid?
+        expect(operator.errors.full_messages).to include('メールアドレス が正しくありません')
       end
     end
 
     context 'password' do
       it '空の状態だと、保存できない。' do
+        operator = build(:operator, password: nil)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('パスワード が空白です')
       end
 
       it '7つ以下の文字列が入力された場合、保存できない。' do
+        operator = build(:operator, password: 'a' * 7, password_confirmation: 'a' * 7)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('パスワード が短すぎです')
       end
     end
 
     context 'password_confirmation' do
       it '空の状態だと、保存できない。' do
+        operator = build(:operator, password_confirmation: nil)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('パスワード(確認) が空白です')
       end
 
       it 'passwordと一致しない場合、保存できない。' do
+        operator = build(:operator, password_confirmation: 'passtext')
+        operator.valid?
+        expect(operator.errors.full_messages).to include('パスワード(確認) が正しくありません')
       end
     end
 
     context 'role' do
       it '空の状態だと、保存できない。' do
-      end
-
-      it '2以上の値が入力された場合、保尊できない。' do
+        operator = build(:operator, role: nil)
+        operator.valid?
+        expect(operator.errors.full_messages).to include('役割 が空白です')
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 概要
Issue #22 
現時点で書ける範囲で、Operatorモデルの単体テストを行います。
（＊メソッドなどが追加された際は別途Issueを立てる予定です）

## 確認事項
【正常】
- [x] name に2以上の文字列が入力された場合、保存できる。(＊)
- [x] name に255以下の文字列が入力された場合、保存できる。
- [x] password に8つ以上の文字列が入力された場合、保存できる。(＊)
- [x] role に0以上の値が入力された場合、保存できる。
- [x] role に1以下の値が入力された場合、保存できる。

【異常】
- [x] name が空の状態だと、保存できない
- [x] name に1以下の文字列が入力された場合、保存できない。(＊)
- [x] name に256以上の文字列が入力された場合、保存できない。
- [x] email が空の状態だと、保存できない
- [x] email に@マークを含まない文字列が入力された場合、保存できない。(＊)
- [x] password に7つ以下の文字列が入力された場合、保存できない。(＊)
- [x] password_confirmation が空の状態だと、保存できない。
- [x] password_confirmation が password と異なる場合、保存できない。
- [x] role が空の状態だと、保存できない。

(＊)：適宜Operatorモデルに必要なバリデーションを加えてください。
