### PR TITLE
[Add] Alarm_content_categoryを実装する #30

### DIFF
--- a/app/controllers/operator/alarm_content_categories_controller.rb
+++ b/app/controllers/operator/alarm_content_categories_controller.rb
@@ -1,0 +1,49 @@
+class Operator::AlarmContentCategoriesController < Operator::BaseController
+  before_action :set_alarm_content_category, only: %i[show edit update destroy]
+
+  def index
+    @alram_content_categories = AlarmContentCategory.all
+  end
+
+  def show; end
+
+  def new
+    @alarm_content_category = AlarmContentCategory.new
+  end
+
+  def create
+    @alarm_content_category = AlarmContentCategory.new(alarm_content_category_params)
+    if @alarm_content_category.save
+      redirect_to operator_alarm_content_categories_path, success: '新しくアラームカテゴリーを作成しました。'
+    else
+      flash.now[:danger] = '入力に不備がありました。'
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @alarm_content_category.update(alarm_content_category_params)
+      redirect_to operator_alarm_content_categories_path, success: 'アラームカテゴリーを更新しました。'
+    else
+      flash.now[:danger] = '入力に不備がありました。'
+      render :edit
+    end
+  end
+
+  def destroy
+    @alarm_content_category.destroy!
+    redirect_to operator_alarm_content_categories_path, success: 'アラームカテゴリーを関連ごと削除しました。'
+  end
+
+  private
+
+  def set_alarm_content_category
+    @alarm_content_category = AlarmContentCategory.find(params[:id])
+  end
+
+  def alarm_content_category_params
+    params.require(:alarm_content_category).permit(:name)
+  end
+end

--- a/app/models/alarm_content_category.rb
+++ b/app/models/alarm_content_category.rb
@@ -1,4 +1,4 @@
 class AlarmContentCategory < ApplicationRecord
   has_many :alarm_contents,   dependent: :destroy
-  validates :name,            presence: true, length: { maximum: 255 }
+  validates :name,            presence: true, length: { minimum: 2, maximum: 255 }
 end

--- a/app/views/operator/alarm_content_categories/_alarm_content_category.html.slim
+++ b/app/views/operator/alarm_content_categories/_alarm_content_category.html.slim
@@ -1,0 +1,6 @@
+tr
+  td.text-center
+    = alarm_content_category.id
+  td
+    = link_to operator_alarm_content_category_path(alarm_content_category), class: 'link-dark text-decoration-none' do
+      = alarm_content_category.name

--- a/app/views/operator/alarm_content_categories/_form.html.slim
+++ b/app/views/operator/alarm_content_categories/_form.html.slim
@@ -1,0 +1,6 @@
+= form_with model: alarm_content_category, url: url, local: true do |f|
+  .form-group.my-5.offset-2.col-8
+    = f.label :name, AlarmContentCategory.human_attribute_name(:name)
+    = f.text_field :name, class: 'form-control rounded-pill'
+  .form-group.my-5.text-center
+    = f.submit '🐾 送信 🐾', class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/alarm_content_categories/edit.html.slim
+++ b/app/views/operator/alarm_content_categories/edit.html.slim
@@ -1,0 +1,5 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | アラームカテゴリー編集
+    = render 'operator/alarm_content_categories/form', { alarm_content_category: @alarm_content_category, url: operator_alarm_content_category_path(@alarm_content_category) }

--- a/app/views/operator/alarm_content_categories/index.html.slim
+++ b/app/views/operator/alarm_content_categories/index.html.slim
@@ -1,0 +1,17 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | アラームカテゴリー一覧
+    .table-responsive.my-5
+      table.table.table-striped.table-hover.text-nowrap
+        thead.px-5
+          tr
+            th.col-1.text-center
+              | ID
+            th.col-4
+              | アラームカテゴリー名
+        tbody
+          = render @alram_content_categories if @alram_content_categories
+
+    .my-5.text-center
+      = link_to '新規作成', new_operator_alarm_content_category_path, class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/alarm_content_categories/new.html.slim
+++ b/app/views/operator/alarm_content_categories/new.html.slim
@@ -1,0 +1,5 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | 新規アラームカテゴリー作成
+    = render 'operator/alarm_content_categories/form', { alarm_content_category: @alarm_content_category, url: operator_alarm_content_categories_path }

--- a/app/views/operator/alarm_content_categories/show.html.slim
+++ b/app/views/operator/alarm_content_categories/show.html.slim
@@ -1,0 +1,8 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      = @alarm_content_category.name
+    .mt-5.text-center
+      = link_to '🐾 編集 🐾', edit_operator_alarm_content_category_path(@alarm_content_category), class: 'btn btn-secondary rounded-pill font-monospace'
+    .my-5.text-center
+      = link_to '- 削除 -', operator_alarm_content_category_path(@alarm_content_category), class: 'btn btn-danger rounded-pill font-monospace', method: :delete, data: { confirm: '関連のアラームコンテンツも消えてしまいますが、本当に削除しますか？' }

--- a/app/views/operator/content_categories/index.html.slim
+++ b/app/views/operator/content_categories/index.html.slim
@@ -11,7 +11,7 @@
             th.col-4
               | カテゴリー名
         tbody
-          = render @content_categories
+          = render @content_categories if @content_categories
 
     .my-5.text-center
       = link_to '新規作成', new_operator_content_category_path, class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/contents/index.html.slim
+++ b/app/views/operator/contents/index.html.slim
@@ -13,7 +13,7 @@
             th.col-2
               | カテゴリー
         tbody
-          = render @contents
+          = render @contents if @contents
 
     .my-5.text-center
       = link_to '新規作成', new_operator_content_path, class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/shared/_navbar.html.slim
+++ b/app/views/operator/shared/_navbar.html.slim
@@ -21,6 +21,11 @@ nav.navbar.navbar-expand-md.navbar-dark.bg-secondary.fixed-top
             .guide-text
               | コンテンツ
         li.nav-item
+          = link_to operator_alarm_content_categories_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
+            icon.fas.fa-tags.me-2
+            .guide-text
+              | アラームカテゴリー
+        li.nav-item
           = link_to operator_cat_out_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center', method: :delete do
             icon.fas.fa-user-alt.me-2
             .guide-text

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -35,7 +35,12 @@ ja:
               too_long: 'が長すぎです'
             content_category_id:
               blank: 'が空白です'
-
+        alarm_content_category:
+          attributes:
+            name:
+              blank: 'が空白です'
+              too_short: 'が短すぎです'
+              too_long: 'が長すぎです'
 
     models:
       operator: 'オペレーター'
@@ -56,6 +61,9 @@ ja:
         id: 'ID'
         body: '内容'
         content_category_id: 'カテゴリー'
+      alarm_content_category:
+        id: 'ID'
+        name: 'アラームカテゴリー名'
 
   enums:
     operator:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resources :boards, only: %i[index]
     resources :content_categories
     resources :contents
+    resources :alarm_content_categories
   end
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 end

--- a/spec/factories/alarm_content_categories.rb
+++ b/spec/factories/alarm_content_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :alarm_content_category do
+    sequence(:name) { |n| "AlarmCategory_#{n}" }
+  end
+end

--- a/spec/models/alarm_content_category_spec.rb
+++ b/spec/models/alarm_content_category_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe AlarmContentCategory, type: :model do
+  let(:alarm_content_category) { build(:alarm_content_category) }
+
+  describe '正常系テスト' do
+    context '全て有効な場合' do
+      it '保存できる。' do
+        expect(alarm_content_category).to be_valid
+      end
+    end
+
+    context 'name' do
+      it '文字列が2以上の入の場合、保存できる。' do
+        alarm_content_category[:name] = 'a' * 2
+        expect(alarm_content_category).to be_valid
+      end
+
+      it '文字列が255以下の入力の場合、保存できる' do
+        alarm_content_category[:name] = 'a' * 255
+        expect(alarm_content_category).to be_valid
+      end
+    end
+  end
+
+  describe '異常系テスト' do
+    context 'name' do
+      it '空の状態だと、保存できない。' do
+        alarm_content_category[:name] = nil
+        alarm_content_category.valid?
+        expect(alarm_content_category.errors.full_messages).to include('アラームカテゴリー名 が空白です')
+      end
+
+      it '1以下の文字列が入力された場合、保存できない。' do
+        alarm_content_category[:name] = 'a' * 1
+        alarm_content_category.valid?
+        expect(alarm_content_category.errors.full_messages).to include('アラームカテゴリー名 が短すぎです')
+      end
+
+      it '256以上の文字列が入力された場合、保存できない。' do
+        alarm_content_category[:name] = 'a' * 256
+        alarm_content_category.valid?
+        expect(alarm_content_category.errors.full_messages).to include('アラームカテゴリー名 が長すぎです')
+      end
+    end
+  end
+end

--- a/spec/system/alarm_content_categories_spec.rb
+++ b/spec/system/alarm_content_categories_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe '[SystemTest] AlarmContentCategories', type: :system do
+  let(:operator) { create :operator }
+  let(:alarm_content_category) { create :alarm_content_category }
+
+  before do
+    login(operator)
+    alarm_content_category
+  end
+
+  context 'アラームカテゴリー一覧' do
+    it 'ログイン後、ナビバーの「アラームカテゴリー」からアラームカテゴリー一覧画面に遷移する。' do
+      click_on 'アラームカテゴリー'
+      expect(page).to have_content('アラームカテゴリー一覧')
+    end
+  end
+
+  context '新規アラームカテゴリー作成' do
+    it 'アラームカテゴリー一覧から新規作成を行い、アラームカテゴリー一覧に戻ってくる。その際、新規作成したアラームカテゴリーが存在する。' do
+      visit operator_alarm_content_categories_path
+      click_on '新規作成'
+      fill_in 'alarm_content_category[name]', with: 'New_Alarm_Category'
+      click_on '🐾 送信 🐾'
+      expect(page).to have_content('アラームカテゴリー一覧')
+      expect(page).to have_content('New_Alarm_Category')
+    end
+  end
+
+  context 'アラームカテゴリー編集・更新' do
+    it 'アラームカテゴリー一覧から編集・更新を行い、アラームカテゴリー一覧に戻ってくる。その際、更新しアラームカテゴリーが存在する。' do
+      visit operator_alarm_content_categories_path
+      click_on alarm_content_category.name.to_s
+      click_on '🐾 編集 🐾'
+      fill_in 'alarm_content_category[name]', with: 'Update_Alarm_Category'
+      click_on '🐾 送信 🐾'
+      expect(page).to have_content('アラームカテゴリー一覧')
+      expect(page).to have_content('Update_Alarm_Category')
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #30 
Alarm_content_category全般(CRUD)を実装します。
以下参照先のIssueに記載されている確認項目になります。

## 確認項目
・モデル及びマイグレーションファイルは既にあるものを使用。
・ログイン後のナビバーの部分に「アラームカテゴリー」と表示される。
・上記のリンクを踏むと、一覧画面が表示され、new, showのリンクがある。
・new(form) → create → index で遷移する。
・show → edit(form) → update → index で遷移する。
・show → destroy → index で遷移する。
・フラッシュメッセージも適切なものを表示する。
・各ビューはContentを参考に作成。
・AlarmContentCategoryモデルの単体テストを行う。
・systemテストにて新規登録・編集・更新の確認を行う。