### PR TITLE
[Add] AlarmContentを実装する #32

### DIFF
--- a/app/controllers/operator/alarm_contents_controller.rb
+++ b/app/controllers/operator/alarm_contents_controller.rb
@@ -1,0 +1,49 @@
+class Operator::AlarmContentsController < Operator::BaseController
+  before_action :set_alarm_content, only: %i[show edit update destroy]
+
+  def index
+    @alarm_contents = AlarmContent.all.includes(:alarm_content_category)
+  end
+
+  def show; end
+
+  def new
+    @alarm_content = AlarmContent.new
+  end
+
+  def create
+    @alarm_content = AlarmContent.new(alarm_content_params)
+    if @alarm_content.save
+      redirect_to operator_alarm_contents_path, success: '新しくコンテンツを作成しました。'
+    else
+      flash.now[:danger] = '入力に不備がありました。'
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @alarm_content.update(alarm_content_params)
+      redirect_to operator_alarm_contents_path, success: 'コンテンツを更新しました。'
+    else
+      flash.now[:danger] = '入力に不備がありました。'
+      render :edit
+    end
+  end
+
+  def destroy
+    @alarm_content.destroy!
+    redirect_to operator_alarm_contents_path, success: 'コンテンツを削除しました。'
+  end
+
+  private
+
+  def set_alarm_content
+    @alarm_content = AlarmContent.find(params[:id])
+  end
+
+  def alarm_content_params
+    params.require(:alarm_content).permit(:body, :alarm_content_category_id)
+  end
+end

--- a/app/views/operator/alarm_contents/_alarm_content.html.slim
+++ b/app/views/operator/alarm_contents/_alarm_content.html.slim
@@ -1,0 +1,8 @@
+tr
+  td.text-center
+    = alarm_content.id
+  td
+    = link_to operator_alarm_content_path(alarm_content), class: 'link-dark text-decoration-none' do
+      = alarm_content.body
+  td
+    = alarm_content.alarm_content_category.name

--- a/app/views/operator/alarm_contents/_form.html.slim
+++ b/app/views/operator/alarm_contents/_form.html.slim
@@ -1,0 +1,9 @@
+= form_with model: alarm_content, url: url, local: true do |f|
+  .form-group.my-5.offset-2.col-8
+    = f.label :body, AlarmContent.human_attribute_name(:body)
+    = f.text_field :body, class: 'form-control rounded-pill'
+  .form-group.my-5.offset-2.col-8
+    = f.label :alarm_content_category_id, AlarmContent.human_attribute_name(:alarm_content_category_id)
+    = f.select :alarm_content_category_id, AlarmContentCategory.all.map{|alarm_category| [alarm_category.name, alarm_category.id]}, {}, class: 'form-control rounded-pill'
+  .form-group.my-5.text-center
+    = f.submit '🐾 送信 🐾', class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/alarm_contents/edit.html.slim
+++ b/app/views/operator/alarm_contents/edit.html.slim
@@ -1,0 +1,5 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | アラームコンテンツ編集
+    = render 'operator/alarm_contents/form', { content: @alarm_content, url: operator_alarm_content_path(@alarm_content) }

--- a/app/views/operator/alarm_contents/index.html.slim
+++ b/app/views/operator/alarm_contents/index.html.slim
@@ -1,0 +1,19 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | アラームコンテンツ一覧
+    .table-responsive.my-5
+      table.table.table-striped.table-hover.text-nowrap
+        thead.px-5
+          tr
+            th.col-1.text-center
+              | ID
+            th.col-4
+              | アラームコンテンツ内容
+            th.col-2
+              | アラームカテゴリー
+        tbody
+          = render @alarm_contents if @alarm_contents
+
+    .my-5.text-center
+      = link_to '新規作成', new_operator_alarm_content_path, class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/alarm_contents/new.html.slim
+++ b/app/views/operator/alarm_contents/new.html.slim
@@ -1,0 +1,5 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | 新規アラームコンテンツ作成
+    = render 'operator/alarm_contents/form', { alarm_content: @alarm_content, url: operator_alarm_contents_path }

--- a/app/views/operator/alarm_contents/show.html.slim
+++ b/app/views/operator/alarm_contents/show.html.slim
@@ -1,0 +1,11 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      = @alarm_content.body
+    h3.mt-5.text-center
+      | アラームカテゴリー：
+      = @alarm_content.alarm_content_category.name
+    .mt-5.text-center
+      = link_to '🐾 編集 🐾', edit_operator_alarm_content_path(@alarm_content), class: 'btn btn-secondary rounded-pill font-monospace'
+    .my-5.text-center
+      = link_to '- 削除 -', operator_alarm_content_path(@alarm_content), class: 'btn btn-danger rounded-pill font-monospace', method: :delete, data: { confirm: '本当に削除しますか？' }

--- a/app/views/operator/shared/_navbar.html.slim
+++ b/app/views/operator/shared/_navbar.html.slim
@@ -26,6 +26,11 @@ nav.navbar.navbar-expand-md.navbar-dark.bg-secondary.fixed-top
             .guide-text
               | アラームカテゴリー
         li.nav-item
+          = link_to operator_alarm_contents_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
+            icon.fas.fa-stopwatch.me-2
+            .guide-text
+              | アラームコンテンツ
+        li.nav-item
           = link_to operator_cat_out_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center', method: :delete do
             icon.fas.fa-user-alt.me-2
             .guide-text

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     resources :content_categories
     resources :contents
     resources :alarm_content_categories
+    resources :alarm_contents
   end
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
Issue #32 
AlarmContent（CRUD）を実装します。

AlarmContentは LINE グループ に送信する中身になるので、
新規作成・編集・更新がちゃんと機能しているか、
人力のブラウザ操作だけでなく、systemテストも用いた上で実装します。

## 確認項目(Issueより)
・モデルやマイグレーションファイルは既に出来ているのを使用。
・コントローラーを作成し、対応するCRUD(ページ含む)の実装。
・AlarmContentモデルの単体テストを行う。
・systemテストにて新規登録・編集・更新の確認を行ってください。
・画面構成はContentを参考に同様のもので構いません。

※現状スマートフォンに合わせていますが、今後PC画面への対応や表示の仕方を変更する際は、別途Issueを立てます。