### PR TITLE
[Add] LineGroupモデルの単体テストを実装する#35

### DIFF
--- a/app/models/line_group.rb
+++ b/app/models/line_group.rb
@@ -3,5 +3,5 @@ class LineGroup < ApplicationRecord
 
   validates :line_group_id, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :remind_at,     presence: true
-  validates :status,        presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2 }
+  validates :status,        presence: true
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,6 +12,7 @@ ja:
               too_long: 'が長すぎです'
             email:
               blank: 'が空白です'
+              taken: 'が重複しています'
               invalid: 'が正しくありません'
             password:
               blank: 'が空白です'
@@ -49,6 +50,16 @@ ja:
               too_long: 'が長すぎです'
             alarm_content_category_id:
               blank: 'が空白です'
+        line_group:
+          attributes:
+            line_group_id:
+              blank: 'が空白です'
+              taken: 'が重複しています'
+              too_long: 'が長すぎです'
+            remind_at:
+              blank: 'が空白です'
+            status:
+              blank: 'が空白です'
 
     models:
       operator: 'オペレーター'
@@ -76,6 +87,12 @@ ja:
         id: 'ID'
         body: '内容'
         alarm_content_category_id: 'アラームカテゴリー'
+      line_group:
+        id: 'ID'
+        line_group_id: 'グループID'
+        remind_at: 'リマインド'
+        status: '状態'
+
 
   enums:
     operator:

--- a/spec/factories/line_groups.rb
+++ b/spec/factories/line_groups.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :line_group do
     sequence(:line_group_id) { |n| "Line_Group_Id:No#{n}" }
-    remid_at Time.current.slince(21.days)
+    remind_at { Time.current.since(21.days) }
     status { :wait }
   end
 end

--- a/spec/factories/line_groups.rb
+++ b/spec/factories/line_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :line_group do
+    sequence(:line_group_id) { |n| "Line_Group_Id:No#{n}" }
+    remid_at Time.current.slince(21.days)
+    status { :wait }
+  end
+end

--- a/spec/models/line_group_spec.rb
+++ b/spec/models/line_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LineGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/line_group_spec.rb
+++ b/spec/models/line_group_spec.rb
@@ -1,5 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe LineGroup, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:line_group) { create(:line_group) }
+
+  describe '正常系テスト' do
+    context '全て有効な場合' do
+      it '保存できる。' do
+        expect(line_group).to be_valid
+      end
+    end
+
+    context 'line_group_id' do
+      it '文字列が255以下の場合、保存できる。' do
+        line_group[:line_group_id] = 'a' * 255
+        expect(line_group).to be_valid
+      end
+    end
+  end
+
+  describe '異常系テスト' do
+    context 'line_group_id' do
+      it '空の状態だと、保存できない。' do
+        line_group[:line_group_id] = nil
+        line_group.valid?
+        expect(line_group.errors.full_messages).to include('グループID が空白です')
+      end
+
+      it '一意な値ではない場合、保存できない。' do
+        new_line_group = build(:line_group, line_group_id: line_group.line_group_id)
+        new_line_group.valid?
+        expect(new_line_group.errors.full_messages).to include('グループID が重複しています')
+      end
+
+      it '256以上の文字列が入力された場合、保存できない。' do
+        line_group[:line_group_id] = 'a' * 256
+        line_group.valid?
+        expect(line_group.errors.full_messages).to include('グループID が長すぎです')
+      end
+    end
+
+    context 'remind_at' do
+      it '空の状態だと、保存できない。' do
+        line_group[:remind_at] = nil
+        line_group.valid?
+        expect(line_group.errors.full_messages).to include('リマインド が空白です')
+      end
+    end
+
+    context 'status' do
+      it '空の状態だと、保存できない。' do
+        line_group[:status] = nil
+        line_group.valid?
+        expect(line_group.errors.full_messages).to include('状態 が空白です')
+      end
+    end
+  end
 end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Operator, type: :model do
   let(:operator) { build(:operator) }
+  let(:created_operator) { create(:operator) }
 
   describe '正常系テスト' do
     context '全て有効な場合' do
@@ -75,6 +76,12 @@ RSpec.describe Operator, type: :model do
         operator = build(:operator, email: nil)
         operator.valid?
         expect(operator.errors.full_messages).to include('メールアドレス が空白です')
+      end
+
+      it '一意な値ではない場合、保存できない。' do
+        new_operator = build(:operator, email: created_operator.email)
+        new_operator.valid?
+        expect(new_operator.errors.full_messages).to include('メールアドレス が重複しています')
       end
 
       it '@マークを含まない文字列が入力された場合、保存できない。' do


### PR DESCRIPTION
## 概要
Issue #35 
LineGroupモデルの単体テストを実装します。

## 確認項目(Issueより)
・今後、Line_groupモデルにメソッドが追加された際は、別途Issueを立てる予定です。
・外部サービスが関わる部分なので、不足している項目などがあれば、バリデーションの追加をお願いします。
・RSpecの結果をプルリクエストのコメント上に掲載をお願いします。

【正常】
- [x] line_group_id に255以下の文字列が入力された場合、保存できる。

【異常】
- [x] line_group_id が空白の場合、保存できない。
- [x] line_group_id に一意な値が入力されなかった場合、保存できない。
- [x] ling_group_id に256以上の値が入力された場合、保存できない。
- [x] remind_at が空白の場合、保存できない。
- [x] status が空白の場合、保存できない。