### PR TITLE
[Add] ブルートフォース攻撃への対策を行う(MVP)#48

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:brute_force_protection]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -478,12 +478,12 @@ Rails.application.config.sorcery.configure do |config|
     # How many failed logins are allowed.
     # Default: `50`
     #
-    # user.consecutive_login_retries_amount_limit =
+    user.consecutive_login_retries_amount_limit = 5
 
     # How long the user should be banned, in seconds. 0 for permanent.
     # Default: `60 * 60`
     #
-    # user.login_lock_time_period =
+    user.login_lock_time_period = (60 * 30)
 
     # Unlock token attribute name
     # Default: `:unlock_token`

--- a/db/migrate/20211015070929_sorcery_broute_force_protection.rb
+++ b/db/migrate/20211015070929_sorcery_broute_force_protection.rb
@@ -1,0 +1,9 @@
+class SorceryBrouteForceProtection < ActiveRecord::Migration[6.1]
+  def change
+    add_column :operators, :failed_logins_count, :integer, default: 0
+    add_column :operators, :lock_expires_at, :datetime, default: nil
+    add_column :operators, :unlock_token, :string, default: nil
+
+    add_index :operators, :unlock_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_073250) do
+ActiveRecord::Schema.define(version: 2021_10_15_070929) do
 
   create_table "alarm_contents", charset: "utf8mb4", force: :cascade do |t|
     t.string "body", null: false
@@ -45,7 +45,11 @@ ActiveRecord::Schema.define(version: 2021_10_04_073250) do
     t.integer "role", default: 1, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "failed_logins_count", default: 0
+    t.datetime "lock_expires_at"
+    t.string "unlock_token"
     t.index ["email"], name: "index_operators_on_email", unique: true
+    t.index ["unlock_token"], name: "index_operators_on_unlock_token"
   end
 
 end


### PR DESCRIPTION
## 概要
Issue #48 
gem 'sorcery' を活用して、ブルートフォース攻撃への対策を実装します。

## 現状
ブルートフォース攻撃に対して、
現状何も対策が取れていないため、
opertorでログインできるemail, passwordの特定が
不可能ではない状態にあると考えます。

現在、email, passwordに正しいものが入力されない場合、
特にエラーメッセージを表示させない仕様になっているため、
推測がされにくい状況とはいえ、
完全に特定できないかといえばゼロではない状態です。

## MVPの考えに基づいて
gem 'sorcery'のGitHubの該当箇所を見ると、
メイラーを活用しているのが見て取れましたが、
今回はMVPの観点から、
特定の回数失敗した際に、一定時間ロックが掛かる機能の実装に留めようと思います。