### PR TITLE
[Fix] メッセージオブジェクトにフィルターを加える

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,5 +2,7 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :groupId, :roomId, :userId
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  :groupId, :roomId, :userId, :text, :originalContentUrl, :previewImageUrl,
+  :address, :latitude, :longitude, :packageId, :stickerId
 ]


### PR DESCRIPTION
## 概要
Issue #50 
LINEグループ上でやり取りされるメッセージオブジェクトに対して、ログに表示されないようにフィルターを加える修正を行います。

LINE Messaging APIリファレンス
https://developers.line.biz/ja/reference/messaging-api/#message-objects