### PR TITLE
[Fix] bundle lock --add-platform x86_64-linux コマンドを実行する#54

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.6)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -330,6 +332,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要
Issue #54 
Herokuへの仮デプロイを行った際に(heroku push origin main)、
表示されたログに`bundle lock --add-platform x86_64-linux`コマンドを実行し、
再度デプロイを試みるようにとの表示があったため、
本プルリクエストでは上記のコマンドを実行します。
