### PR TITLE
[Fix] BootstrapのCSS関連をSpocketsに切り替える#56

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,12 +24,12 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'slim-rails'
-gem 'html2slim'
 gem 'font-awesome-sass'
 gem 'sorcery'
 gem 'enum_help'
 gem 'line-bot-api'
 gem 'pundit'
+gem 'bootstrap', '~> 5.1.0'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    autoprefixer-rails (10.3.3.0)
+      execjs (~> 2)
     bcrypt (3.1.16)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -71,6 +73,10 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
+    bootstrap (5.1.0)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.9.3, < 3)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     bullet (6.1.5)
       activesupport (>= 3.0.0)
@@ -92,6 +98,7 @@ GEM
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
+    execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -123,9 +130,6 @@ GEM
       sassc (>= 1.11)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    hpricot (0.8.6)
-    html2slim (0.2.0)
-      hpricot
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -173,6 +177,7 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    popper_js (2.9.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -337,6 +342,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   bootsnap (>= 1.4.4)
+  bootstrap (~> 5.1.0)
   bullet
   byebug
   capybara
@@ -344,7 +350,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   font-awesome-sass
-  html2slim
   jbuilder (~> 2.7)
   letter_opener_web
   line-bot-api

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
+@import 'bootstrap';
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
 @import 'layout';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,5 +10,4 @@ import "channels"
 Rails.start()
 ActiveStorage.start()
 
-import "../stylesheets/application"
 import "../javascript/bootstrap.js"

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,0 @@
-@import "bootstrap";


### PR DESCRIPTION
## 概要
Issue #56 
Bootstrap5のCSS関連を、webpackerからsprocketsに切り替えます。

## 理由
gem 'bootstrap' の5系がbeta版ではなく、
正式なバージョンがリリースされているのを受けて、
assets関連をsprocketsに集約することを目的に実装を行います。