### PR TITLE
[Fix] rakeファイル内にあるトランザクションを削除する#66

### DIFF
--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -4,25 +4,20 @@ namespace :call_notice do
   task call_reminds: :environment do
     client = ClientConfig.set_line_bot_client
 
-    # 送信するメッセージ選定
-    contact_message   = { type: 'text', text: AlarmContent.contact.sample.body }
-    proposal_message  = { type: 'text', text: AlarmContent.proposal.sample.body }
-    url_message       = { type: 'text', text: AlarmContent.url.sample.body }
-    naive_message     = { type: 'text', text: AlarmContent.naive.sample.body }
-    free_message      = { type: 'text', text: AlarmContent.free.sample.body }
+    messages = [{ type: 'text', text: Alarmcontent.contact.sample.body },
+                { type: 'text', text: AlarmContent.proposal.sample.body },
+                { type: 'text', text: AlarmContent.url.sample.body },
+                { type: 'text', text: AlarmContent.naive.sample.body },
+                { type: 'text', text: AlarmContent.free.sample.body }]
 
     remaind_groups = LineGroup.remind_call
     remaind_groups.find_each do |group|
-      LineGroup.transaction do
-        # === 現状だと送信が上手くいかなかった際にtransactionは機能していません ===
-        client.push_message(group.line_group_id, contact_message)
-        client.push_message(group.line_group_id, proposal_message)
-        client.push_message(group.line_group_id, url_message)
-        client.push_message(group.line_group_id, naive_message)
-        client.push_message(group.line_group_id, free_message)
-        group.remind_at = Date.current.since((7..12).to_a.sample.days)
-        group.save!
+      response = ''
+      messages.each do |message|
+        response = client.push_message(group.line_group_id, message) if response.code != '400'
       end
+      group.remind_at = Date.current.since((7..12).to_a.sample.days)
+      group.save! if response.code != '400'
     end
   end
 end

--- a/lib/tasks/wait_notice.rake
+++ b/lib/tasks/wait_notice.rake
@@ -4,21 +4,18 @@ namespace :wait_notice do
   task wait_contents: :environment do
     client = ClientConfig.set_line_bot_client
 
-    # 送信するメッセージ選定
-    call_message  = { type: 'text', text: Content.call.sample.body }
-    movie_message = { type: 'text', text: Content.movie.sample.body }
-    free_message  = { type: 'text', text: Content.free.sample.body }
+    messages = [{ type: 'text', text: Content.call.sample.body },
+                { type: 'text', text: Content.movie.sample.body },
+                { type: 'text', text: Content.free.sample.body }]
 
     remaind_groups = LineGroup.remind_wait
     remaind_groups.find_each do |group|
-      LineGroup.transaction do
-        # === 現状だと送信が上手くいかなかった際にtransactionは機能していません ===
-        client.push_message(group.line_group_id, call_message)
-        client.push_message(group.line_group_id, movie_message)
-        client.push_message(group.line_group_id, free_message)
-        group.remind_at = Date.current.since((3..5).to_a.sample.days)
-        group.call!
+      response = ''
+      messages.each do |message|
+        response = client.push_message(group.line_group_id, message) if response.code != '400'
       end
+      group.remind_at = Date.current.since((3..5).to_a.sample.days)
+      group.call! if response.code != '400'
     end
   end
 end


### PR DESCRIPTION
## 概要
Issue #66 
lib/tasks/以下にある以下の2つのrakeファイルを修正してください。

- call_notice.rake
- wait_notice.rake

トランザクションを削除し、
各働きかけメッセージでエラーが発生した際、
（=HTTPステータスコードが'400'だった場合）
remind_atの値が更新されないようにしてください。

参考URL：LINE Developers
https://developers.line.biz/ja/reference/messaging-api/#send-push-message-error-response