### PR TITLE
[Fix] タイプミスを修正する#66

### DIFF
--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -4,7 +4,7 @@ namespace :call_notice do
   task call_reminds: :environment do
     client = ClientConfig.set_line_bot_client
 
-    messages = [{ type: 'text', text: Alarmcontent.contact.sample.body },
+    messages = [{ type: 'text', text: AlarmContent.contact.sample.body },
                 { type: 'text', text: AlarmContent.proposal.sample.body },
                 { type: 'text', text: AlarmContent.url.sample.body },
                 { type: 'text', text: AlarmContent.naive.sample.body },


### PR DESCRIPTION
## 概要
Issue #66 
lib/tasks/call_notice.rake内のタイプミスを修正する。

Alarmcontent → AlarmContent