### PR TITLE
[Fix] lib/tasks/call_notice.rake内のloggerを削除する#66

### DIFF
--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -15,7 +15,6 @@ namespace :call_notice do
       response = ''
       messages.each do |message|
         response = client.push_message(group.line_group_id, message) if response.blank? || response.code == '200'
-        logger.info response.code
       end
       group.remind_at = Date.current.since((7..12).to_a.sample.days)
       group.save! if response.code == '200'


### PR DESCRIPTION
概要
Issue #66 
ローカル環境では問題ありませんでしたが、
Heroku上ではloggerがエラーを発生させる要因になっていた為、
loggerの一行を削除する修正を行います。