### PR TITLE
[Add] フィードバック投稿機能を実装する#9

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -5,3 +5,8 @@ body {
 .web-font {
   font-family: 'Hachi Maru Pop', cursive;
 }
+
+.feedback-input {
+  resize: none;
+  height: 280px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Pundit
   rescue_from Pundit::NotAuthorizedError, with: :operator_not_authorized
+  add_flash_types :success, :info, :warning, :danger
 
   def operator_not_authorized
     render file: Rails.root.join('public/403.html'), status: :forbidden, layout: false, content_type: 'text/html'

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,2 @@
+class FeedbacksController < ApplicationController
+end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,2 +1,21 @@
 class FeedbacksController < ApplicationController
+  def new
+    @feedback = Feedback.new
+  end
+
+  def create
+    @feedback = Feedback.new(feedback_params)
+    if @feedback.save
+      redirect_to root_path, success: 'フィードバックありがとうございます！'
+    else
+      flash.now[:danger] = '100〜300文字でお願いします！🐾'
+      render :new
+    end
+  end
+
+  private
+
+  def feedback_params
+    params.require(:feedback).permit(:text)
+  end
 end

--- a/app/controllers/operator/base_controller.rb
+++ b/app/controllers/operator/base_controller.rb
@@ -1,5 +1,4 @@
 class Operator::BaseController < ApplicationController
-  add_flash_types :success, :info, :warning, :danger
   layout 'operator/layouts/application'
   before_action :require_login
 

--- a/app/models/alarm_content.rb
+++ b/app/models/alarm_content.rb
@@ -1,5 +1,5 @@
 class AlarmContent < ApplicationRecord
   enum category: { contact: 0, proposal: 1, url: 2, naive: 3, free: 4 }
-  validates :body,       presence: true, uniqueness: true, length: { minimum: 2, maximum: 255 }
+  validates :body,       presence: true, uniqueness: true, length: { in: 2..255 }
   validates :category,   presence: true
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,5 +1,5 @@
 class Content < ApplicationRecord
   enum category: { call: 0, movie: 1, free: 2 }
-  validates :body,       presence: true, uniqueness: true, length: { minimum: 2, maximum: 255 }
+  validates :body,       presence: true, uniqueness: true, length: { in: 2..255 }
   validates :category,   presence: true
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,3 @@
+class Feedback < ApplicationRecord
+  validates :text, presence: true, length: { minimum: 100, maximum: 300 }
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,3 +1,3 @@
 class Feedback < ApplicationRecord
-  validates :text, presence: true, length: { minimum: 100, maximum: 300 }
+  validates :text, presence: true, length: { in: 100..300 }
 end

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -2,7 +2,7 @@ class Operator < ApplicationRecord
   authenticates_with_sorcery!
   enum role: { operator: 0, guest: 1 }
 
-  validates :name,                    presence: true, length: { minimum: 2, maximum: 255 }
+  validates :name,                    presence: true, length: { in: 2..255 }
   validates :email,                   presence: true, uniqueness: true
   validates :email,                   format: { with: /\A[a-z0-9_-]+@[a-z0-9_-]+[\\.][a-z0-9_-]+/ }
   validates :password,                presence: true

--- a/app/views/feedbacks/new.html.slim
+++ b/app/views/feedbacks/new.html.slim
@@ -1,0 +1,10 @@
+.container-fluid.mx-auto
+  .row
+    h1.mt-5.text-center
+      | フィードバック
+    = form_with model: @feedback, local: true do |f|
+      .form-group.my-5.offset-2.col-8
+        = f.label :text, Feedback.human_attribute_name(:text)
+        = f.text_area :text, maxlength: 300, placeholder: '100〜300文字でお願いします🐾', class: 'form-control rounded-3 py-2 px-2 mt-3 feedback-input'
+      .form-group.my-5.text-center
+        = f.submit '🐾 送信 🐾', class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,4 +11,5 @@ html
     = javascript_pack_tag 'application'
   body.web-font
     = render 'shared/navbar'
+    = render 'shared/flash_message'
     = yield

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -25,7 +25,7 @@ nav.navbar.navbar-expand-md.navbar-dark.bg-secondary.fixed-top
           .guide-text
             | プライバシーポリシー
       li.nav-item
-        = link_to '#', class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
+        = link_to new_feedback_path, class: 'nav-link my-1 mx-1 d-inline-flex align-items-center' do
           icon.far.fa-comment.me-2
           .guide-text
             | フィードバック

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -51,8 +51,10 @@ ja:
 
     models:
       operator: 'オペレーター'
-      content_category: 'カテゴリー'
       content: 'コンテンツ'
+      alarm_content: 'アラームコンテンツ'
+      feedback: 'フィードバック'
+      line_group: 'LINEグループ'
     attributes:
       operator:
         id: 'ID'
@@ -69,6 +71,9 @@ ja:
         id: 'ID'
         body: '内容'
         category: 'カテゴリー'
+      feedback:
+        id: 'ID'
+        text: '内容'
       line_group:
         id: 'ID'
         line_group_id: 'グループID'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -38,6 +38,12 @@ ja:
               too_long: 'が長すぎです'
             category:
               blank: 'が空白です'
+        feedback:
+          attributes:
+            text:
+              blank: 'が空白です'
+              too_short: 'が短すぎです'
+              too_long: 'が長すぎです'
         line_group:
           attributes:
             line_group_id:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'customers#top'
   get 'usage', to: 'customers#usage'
+  resources :feedbacks, only: %i[new create]
   namespace :operator do
     get    'cat_in',  to: 'operator_sessions#new'
     post   'cat_in',  to: 'operator_sessions#create'

--- a/db/migrate/20211020135448_create_feedbacks.rb
+++ b/db/migrate/20211020135448_create_feedbacks.rb
@@ -1,0 +1,8 @@
+class CreateFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :feedbacks do |t|
+      t.text :text,   null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_15_070929) do
+ActiveRecord::Schema.define(version: 2021_10_20_135448) do
 
   create_table "alarm_contents", charset: "utf8mb4", force: :cascade do |t|
     t.string "body", null: false
@@ -26,6 +26,12 @@ ActiveRecord::Schema.define(version: 2021_10_15_070929) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["body"], name: "index_contents_on_body", unique: true
+  end
+
+  create_table "feedbacks", charset: "utf8mb4", force: :cascade do |t|
+    t.text "text", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "line_groups", charset: "utf8mb4", force: :cascade do |t|

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :feedback do
+    text { "Freedom is it should be free and to become to be inconvenient. #{'.' * 100}" }
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Feedback, type: :model do
+  let(:feedback) { build(:feedback) }
+
+  describe '正常系テスト' do
+    context '全て有効な場合' do
+      it '保存できる。' do
+        expect(feedback).to be_valid
+      end
+    end
+
+    context 'text' do
+      it '文字列が100以上の場合、保存できる。' do
+        feedback[:text] = 'a' * 100
+        expect(feedback).to be_valid
+      end
+
+      it '文字列が300以下の場合、保存できる。' do
+        feedback[:text] = 'a' * 300
+        expect(feedback).to be_valid
+      end
+    end
+  end
+
+  describe '異常系テスト' do
+    context 'text' do
+      it '空の状態だと、保存できない。' do
+        feedback[:text] = nil
+        feedback.valid?
+        expect(feedback.errors.full_messages).to include('内容 が空白です')
+      end
+
+      it '99以下の文字列が入力された場合、保存できない。' do
+        feedback[:text] = 'a' * 99
+        feedback.valid?
+        expect(feedback.errors.full_messages).to include('内容 が短すぎです')
+      end
+
+      it '301以上の文字列が入力された場合、保存できない。' do
+        feedback[:text] = 'a' * 301
+        feedback.valid?
+        expect(feedback.errors.full_messages).to include('内容 が長すぎです')
+      end
+    end
+  end
+end

--- a/spec/system/feedbacks_spec.rb
+++ b/spec/system/feedbacks_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe '[SystemTest] Feedbacks', type: :system do
+  let(:feedback) { build :feedback }
+
+  describe 'フィードバックを投稿' do
+    context '正常系テスト' do
+      it 'トップページからフィードバックへ遷移し、投稿が成功し、トップページに戻ってくる' do
+        visit root_path
+        click_on 'フィードバック'
+        fill_in 'feedback[text]', with: feedback.text
+        click_on '🐾 送信 🐾'
+        expect(page).to have_content('フィードバックありがとうございます！')
+        expect(Feedback.count).to eq 1
+        expect(page).to have_current_path root_path
+      end
+
+      it '100文字の投稿を行うと、トップページに戻ってくる' do
+        visit new_feedback_path
+        fill_in 'feedback[text]', with: 'a' * 100
+        click_on '🐾 送信 🐾'
+        expect(page).to have_content('フィードバックありがとうございます！')
+        expect(Feedback.count).to eq 1
+        expect(page).to have_current_path root_path
+      end
+
+      it '300文字の投稿を行うと、トップページに戻ってくる' do
+        visit new_feedback_path
+        fill_in 'feedback[text]', with: 'a' * 300
+        click_on '🐾 送信 🐾'
+        expect(page).to have_content('フィードバックありがとうございます！')
+        expect(Feedback.count).to eq 1
+        expect(page).to have_current_path root_path
+      end
+    end
+
+    context '異常系テスト' do
+      it '空の投稿を行うと、フラッシュメッセージが表示される' do
+        visit new_feedback_path
+        click_on '🐾 送信 🐾'
+        expect(page).to have_content('100〜300文字でお願いします！🐾')
+        expect(Feedback.count).to eq 0
+        expect(page).to have_current_path feedbacks_path
+      end
+
+      it '99文字以下の投稿を行うと、フラッシュメッセージが表示される' do
+        # 301以上はtext_areaのmaxlengthオプションにより入力できない
+        visit new_feedback_path
+        fill_in 'feedback[text]', with: 'a' * 99
+        click_on '🐾 送信 🐾'
+        expect(page).to have_content('100〜300文字でお願いします！🐾')
+        expect(Feedback.count).to eq 0
+        expect(page).to have_current_path feedbacks_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
概要
Issue #9 
ユーザーがフィードバックできるように、ページの作成及び投稿機能の実装を行います。

・ページ：画面遷移図を参考に作成。
・フィードバック投稿機能：new → create アクションのみ。
　（詳細や削除はOperator側で行う予定です）
・モデルの単体テスト：バリデーションチェック。
・systemテスト：バリデーションチェック＆遷移先確認。

確認方法
systemテストにて画面遷移の確認、入力文字数に応じてバリデーションが機能しているかの確認、登録条件を満たしていた場合のFeedbacksテーブルのカウント数の変化を確認します。

＊１つ前のプルリクエストのマージで失策があったため、本ブランチ＆プルリクエストにて修正版を適応します。