### PR TITLE
[Fix] Content(Alarm含む)のenumの命名を修正する#102

### DIFF
--- a/app/models/alarm_content.rb
+++ b/app/models/alarm_content.rb
@@ -1,5 +1,5 @@
 class AlarmContent < ApplicationRecord
-  enum category: { contact: 0, proposal: 1, url: 2, naive: 3, free: 4 }
+  enum category: { contact: 0, free_one: 1, free_two: 2, free_three: 3, text: 4 }
   validates :body,       presence: true, uniqueness: true, length: { in: 2..255 }
   validates :category,   presence: true
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,5 +1,5 @@
 class Content < ApplicationRecord
-  enum category: { call: 0, movie: 1, free: 2 }
+  enum category: { contact: 0, free: 1, text: 2 }
   validates :body,       presence: true, uniqueness: true, length: { in: 2..255 }
   validates :category,   presence: true
 end

--- a/config/locales/enum/ja.yml
+++ b/config/locales/enum/ja.yml
@@ -6,16 +6,16 @@ ja:
         guest: 'ゲスト'
     content:
       category:
-        call: '呼びかけ'
-        movie: '動画(URL)'
-        free: '自由記載'
+        contact: 'コンタクト'
+        free: '自由記述'
+        text: 'テキスト'
     alarm_content:
       category:
         contact: 'コンタクト'
-        proposal: '提案'
-        url: 'URL'
-        naive: 'ナイーブ'
-        free: '自由記載'
+        free_one: '自由記述１'
+        free_two: '自由記述２'
+        free_three: '自由期日２'
+        text: 'テキスト'
     line_group:
       status:
         wait: '呼びかけ前'

--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -5,10 +5,10 @@ namespace :call_notice do
     client = ClientConfig.set_line_bot_client
 
     messages = [{ type: 'text', text: AlarmContent.contact.sample.body },
-                { type: 'text', text: AlarmContent.proposal.sample.body },
-                { type: 'text', text: AlarmContent.url.sample.body },
-                { type: 'text', text: AlarmContent.naive.sample.body },
-                { type: 'text', text: AlarmContent.free.sample.body }]
+                { type: 'text', text: AlarmContent.free_one.sample.body },
+                { type: 'text', text: AlarmContent.free_two.sample.body },
+                { type: 'text', text: AlarmContent.free_three.sample.body },
+                { type: 'text', text: AlarmContent.text.sample.body }]
 
     remaind_groups = LineGroup.remind_call
     remaind_groups.find_each do |group|

--- a/lib/tasks/wait_notice.rake
+++ b/lib/tasks/wait_notice.rake
@@ -4,9 +4,9 @@ namespace :wait_notice do
   task wait_reminds: :environment do
     client = ClientConfig.set_line_bot_client
 
-    messages = [{ type: 'text', text: Content.call.sample.body },
-                { type: 'text', text: Content.movie.sample.body },
-                { type: 'text', text: Content.free.sample.body }]
+    messages = [{ type: 'text', text: Content.contact.sample.body },
+                { type: 'text', text: Content.free.sample.body },
+                { type: 'text', text: Content.text.sample.body }]
 
     remaind_groups = LineGroup.remind_wait
     remaind_groups.find_each do |group|

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :content do
     sequence(:body) { |n| "Content_#{n}" }
-    category { :call }
+    category { :contact }
   end
 end

--- a/spec/system/contents_spec.rb
+++ b/spec/system/contents_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '[SystemTest] Contents', type: :system do
       visit operator_contents_path
       click_on '新規作成'
       fill_in 'content[body]', with: 'New_Content'
-      select '呼びかけ', from: 'カテゴリー'
+      select 'コンタクト', from: 'カテゴリー'
       click_on '🐾 送信 🐾'
       expect(page).to have_content('コンテンツ一覧')
       expect(page).to have_content('New_Content'.truncate(10))
@@ -31,7 +31,7 @@ RSpec.describe '[SystemTest] Contents', type: :system do
       visit operator_contents_path
       click_on '新規作成'
       fill_in 'content[body]', with: nil
-      select '呼びかけ', from: 'カテゴリー'
+      select 'コンタクト', from: 'カテゴリー'
       click_on '🐾 送信 🐾'
       expect(page).to have_content('新規コンテンツ作成')
       expect(page).to have_content('入力に不備がありました。')


### PR DESCRIPTION
## 概要
Issue #102 
Content(Alarm含む)のenumの命名を修正します。

movie などの特定の命名だと、
それ以外の要素を登録することに違和感が発生するのと、
送信する働きかけが似たりよったりのものになってしまうため、
ある程度の拡張性を持たせる形に修正します。
