### PR TITLE
[Fix] 管理運営ページの一覧画面を昇順で表示させるように修正する

### DIFF
--- a/app/controllers/operator/alarm_contents_controller.rb
+++ b/app/controllers/operator/alarm_contents_controller.rb
@@ -4,7 +4,7 @@ class Operator::AlarmContentsController < Operator::BaseController
   def index
     authorize(AlarmContent)
 
-    @alarm_contents = AlarmContent.all
+    @alarm_contents = AlarmContent.order(id: :asc)
   end
 
   def show

--- a/app/controllers/operator/contents_controller.rb
+++ b/app/controllers/operator/contents_controller.rb
@@ -4,7 +4,7 @@ class Operator::ContentsController < Operator::BaseController
   def index
     authorize(Content)
 
-    @contents = Content.all
+    @contents = Content.order(id: :asc)
   end
 
   def show

--- a/app/controllers/operator/feedbacks_controller.rb
+++ b/app/controllers/operator/feedbacks_controller.rb
@@ -4,7 +4,7 @@ class Operator::FeedbacksController < Operator::BaseController
   def index
     authorize(Feedback)
 
-    @feedbacks = Feedback.all
+    @feedbacks = Feedback.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/operator/line_groups_controller.rb
+++ b/app/controllers/operator/line_groups_controller.rb
@@ -4,7 +4,7 @@ class Operator::LineGroupsController < Operator::BaseController
   def index
     authorize(LineGroup)
 
-    @line_groups      = LineGroup.all
+    @line_groups      = LineGroup.order(id: :asc)
     @sum_post_count   = @line_groups.sum(:post_count)
     @sum_member_count = @line_groups.sum(:member_count)
   end

--- a/app/views/operator/alarm_contents/show.html.slim
+++ b/app/views/operator/alarm_contents/show.html.slim
@@ -2,7 +2,7 @@ h1.mt-5.text-center
   = @alarm_content.body
 h3.mt-5.text-center
   | アラームカテゴリー：
-  = @alarm_content.category
+  = @alarm_content.category_i18n
 - if current_user.operator?
   .mt-5.text-center
     = link_to '🐾 編集 🐾', edit_operator_alarm_content_path(@alarm_content), class: 'btn btn-secondary rounded-pill font-monospace'

--- a/app/views/operator/contents/show.html.slim
+++ b/app/views/operator/contents/show.html.slim
@@ -2,7 +2,7 @@ h1.mt-5.text-center
   = @content.body
 h3.mt-5.text-center
   | カテゴリー：
-  = @content.category
+  = @content.category_i18n
 - if current_user.operator?
   .mt-5.text-center
     = link_to '🐾 編集 🐾', edit_operator_content_path(@content), class: 'btn btn-secondary rounded-pill font-monospace'


### PR DESCRIPTION
## 概要
Issue #105 
管理運営ページ内で表示される一覧画面のレコードを、
"昇順"で表示するように修正を行います。

上記の修正に伴い、他の機能等に影響が出ていないかを
RSpec の system テストを用いて確認をします。