### PR TITLE
[Fix] Joinイベント時のレコード作成部分を修正する#119

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -99,7 +99,7 @@ class Event
 
   # LineGroupsテーブルにレコードが無く、且つメンバーが2人以上の際に新しくレコードを作成する
   def self.create_line_group(group_id, count_menbers)
-    return if LineGroup.find_by(line_group_id: group_id) && count_menbers['count'].to_i < 2
+    return unless LineGroup.find_by(line_group_id: group_id).nil? && count_menbers['count'].to_i > 1
 
     LineGroup.create!(line_group_id: group_id, remind_at: Date.current.tomorrow,
                       status: :wait, member_count: count_menbers['count'].to_i)


### PR DESCRIPTION
## 概要
Issue #119 #120 
Joinイベント時にLineGroupsテーブルのレコードを作成する箇所で、
バグが発生しているため、if 文から unless 文に書き換えて、
レコード作成される条件を整えます。