### PR TITLE
[Fix] フィードバック入力可能領域を30〜500文字に修正する#122

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -8,7 +8,7 @@ class FeedbacksController < ApplicationController
     if @feedback.save
       redirect_to root_path, success: 'フィードバックありがとうございます！'
     else
-      flash.now[:danger] = '100〜300文字でお願いします！🐾'
+      flash.now[:danger] = '30〜500文字でお願いします！🐾'
       render :new
     end
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,3 +1,3 @@
 class Feedback < ApplicationRecord
-  validates :text, presence: true, length: { in: 100..300 }
+  validates :text, presence: true, length: { in: 30..500 }
 end

--- a/app/views/feedbacks/new.html.slim
+++ b/app/views/feedbacks/new.html.slim
@@ -3,6 +3,6 @@ h1.mt-5
 = form_with model: @feedback, local: true do |f|
   .form-group.my-5.offset-2.col-8
     = f.label :text, Feedback.human_attribute_name(:text)
-    = f.text_area :text, maxlength: 300, placeholder: '100〜300文字でお願いします🐾', class: 'form-control rounded-3 py-2 px-2 mt-3 feedback-input'
+    = f.text_area :text, maxlength: 500, placeholder: '30〜500文字でお願いします🐾', class: 'form-control rounded-3 py-2 px-2 mt-3 feedback-input'
   .form-group.my-5
     = f.submit '🐾 送信 🐾', class: 'btn btn-secondary rounded-pill font-monospace'

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Feedback, type: :model do
     end
 
     context 'text' do
-      it '文字列が100以上の場合、保存できる。' do
-        feedback[:text] = 'a' * 100
+      it '文字列が30上の場合、保存できる。' do
+        feedback[:text] = 'a' * 30
         expect(feedback).to be_valid
       end
 
-      it '文字列が300以下の場合、保存できる。' do
-        feedback[:text] = 'a' * 300
+      it '文字列が500以下の場合、保存できる。' do
+        feedback[:text] = 'a' * 500
         expect(feedback).to be_valid
       end
     end
@@ -31,14 +31,14 @@ RSpec.describe Feedback, type: :model do
         expect(feedback.errors.full_messages).to include('内容 が空白です')
       end
 
-      it '99以下の文字列が入力された場合、保存できない。' do
-        feedback[:text] = 'a' * 99
+      it '29以下の文字列が入力された場合、保存できない。' do
+        feedback[:text] = 'a' * 29
         feedback.valid?
         expect(feedback.errors.full_messages).to include('内容 が短すぎです')
       end
 
-      it '301以上の文字列が入力された場合、保存できない。' do
-        feedback[:text] = 'a' * 301
+      it '501以上の文字列が入力された場合、保存できない。' do
+        feedback[:text] = 'a' * 501
         feedback.valid?
         expect(feedback.errors.full_messages).to include('内容 が長すぎです')
       end

--- a/spec/system/feedbacks_spec.rb
+++ b/spec/system/feedbacks_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe '[SystemTest] Feedbacks', type: :system do
         expect(page).to have_current_path root_path
       end
 
-      it '100文字の投稿を行うと、トップページに戻ってくる' do
+      it '30文字の投稿を行うと、トップページに戻ってくる' do
         visit new_feedback_path
-        fill_in 'feedback[text]', with: 'a' * 100
+        fill_in 'feedback[text]', with: 'a' * 30
         click_on '🐾 送信 🐾'
         expect(page).to have_content('フィードバックありがとうございます！')
         expect(Feedback.count).to eq 1
         expect(page).to have_current_path root_path
       end
 
-      it '300文字の投稿を行うと、トップページに戻ってくる' do
+      it '500文字の投稿を行うと、トップページに戻ってくる' do
         visit new_feedback_path
-        fill_in 'feedback[text]', with: 'a' * 300
+        fill_in 'feedback[text]', with: 'a' * 500
         click_on '🐾 送信 🐾'
         expect(page).to have_content('フィードバックありがとうございます！')
         expect(Feedback.count).to eq 1
@@ -38,17 +38,17 @@ RSpec.describe '[SystemTest] Feedbacks', type: :system do
       it '空の投稿を行うと、フラッシュメッセージが表示される' do
         visit new_feedback_path
         click_on '🐾 送信 🐾'
-        expect(page).to have_content('100〜300文字でお願いします！🐾')
+        expect(page).to have_content('30〜500文字でお願いします！🐾')
         expect(Feedback.count).to eq 0
         expect(page).to have_current_path feedbacks_path
       end
 
-      it '99文字以下の投稿を行うと、フラッシュメッセージが表示される' do
-        # 301以上はtext_areaのmaxlengthオプションにより入力できない
+      it '29文字以下の投稿を行うと、フラッシュメッセージが表示される' do
+        # 501以上はtext_areaのmaxlengthオプションにより入力できない
         visit new_feedback_path
-        fill_in 'feedback[text]', with: 'a' * 99
+        fill_in 'feedback[text]', with: 'a' * 29
         click_on '🐾 送信 🐾'
-        expect(page).to have_content('100〜300文字でお願いします！🐾')
+        expect(page).to have_content('30〜500文字でお願いします！🐾')
         expect(Feedback.count).to eq 0
         expect(page).to have_current_path feedbacks_path
       end


### PR DESCRIPTION
## 概要
Isseu #122 
現状の投稿可能文字数"100〜300"を、"30〜500"に修正します。

それに伴い、
MVC及び単体テスト・systemテストの修正及します。

また、
bundle exec rspec, bundle exec rubocop, コマンドの実行結果を
コメントに記載して問題がないかの確認を行います。