### PR TITLE
[Fix] ユーザーがLINEに投稿をした際のremind_atの値を修正する#124

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -65,7 +65,8 @@ class Event
     json_data = Event.members_count(event, client)
     count_menbers = JSON.parse(json_data.body)
     Event.create_line_group(group_id, count_menbers)
-    message = { type: 'text', text: '加えてくれてありがとうニャ🌟！！最後のLINEから3週間〜2ヶ月後にwake upのLINEするニャ！！よろしくニャ🐱🐾' }
+    message = { type: 'text',
+                text: '加えてくれてありがとうニャ🌟！！最後のLINEから3週間〜2ヶ月後にwake upのLINEするニャ！！（反応が無いとすぐwake upするかも知れニャンよ⏰）末永くよろしくニャ🐱🐾' }
     client.push_message(group_id, message)
   end
 

--- a/app/models/line_group.rb
+++ b/app/models/line_group.rb
@@ -15,7 +15,7 @@ class LineGroup < ApplicationRecord
   scope :remind_call, -> { call.where('remind_at <= ?', Date.current) }
 
   def change_status_to_wait(count_menbers)
-    random_number = (23..60).to_a.sample
+    random_number = (17..50).to_a.sample
     update!(remind_at: Date.current.since(random_number.days),
             status: :wait,
             post_count: post_count + 1,


### PR DESCRIPTION
## 概要
Issue #124 
現在の"23日〜60日後"にwake up投稿を行う設定から、
"17日〜50日後"にwake up投稿を行う設定に修正します。

また、
LINE Bot入室後、反応が無かった(投稿されなかった)際に、
近々でwake up投稿が来ることを示唆する文言を追加します。
