### PR TITLE
[Fix] Lineイベント関係の引数の数を整える#126

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -22,11 +22,11 @@ class Event
       Event.goodbye_cat(event, client, group_id) if event['message']['type'] == Line::Bot::Event::MessageType::Text
       Event.catch_message(event, client, group_id, count_menbers)
     when Line::Bot::Event::Join
-      Event.join_bot(event, client, group_id, count_menbers)
+      Event.join_bot(client, group_id, count_menbers)
     when Line::Bot::Event::MemberJoined
-      Event.join_member(event, client, group_id, count_menbers)
+      Event.join_member(client, group_id, count_menbers)
     when Line::Bot::Event::Leave, Line::Bot::Event::MemberLeft
-      Event.leave_events(event, client, group_id, count_menbers)
+      Event.leave_events(group_id, count_menbers)
     end
   end
 


### PR DESCRIPTION
## 概要
Issue #126 
LINEイベントにおいてバグが発生していることが発覚したため、該当箇所の修正を行います。

該当箇所はapp/lines/event.rb内における引数がチグハグになっている箇所と思われます。
```rb
<Callback> 例外:ArgumentError, メッセージ:wrong number of arguments (given 4, expected 2)
```

修正後、本番環境でもバグが解消されているか確認をします。