### PR TITLE
[Fix] テキスト以外のイベントでエラーが発生しないように修正する#126

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -64,9 +64,10 @@ class Event
 
   # 上記から呼び出しを受けて、投稿されたメッセージに応じてLineGroupレコードの状態を更新します。
   def self.posted_textmessage_by_member(event, client, line_group, count_menbers)
-    if event.message['text'].match?('Cat… Would you set wake up to faster.')
+    event.message['text'] ||= 'テキスト以外の通信です'
+    if event.message['text'].match?('Would you set to faster.')
       Event.change_status_by_short_magicword(client, line_group, count_menbers)
-    elsif event.message['text'].match?('Cat… Would you set wake up post to latter.')
+    elsif event.message['text'].match?('Would you set to latter.')
       Event.change_status_by_long_magicword(client, line_group, count_menbers)
     else
       line_group.auto_change_status(count_menbers['count'].to_i)

--- a/app/views/customers/top.html.slim
+++ b/app/views/customers/top.html.slim
@@ -39,6 +39,8 @@ h1.mt-5
     | 最後の投稿から<br>3週間〜2ヶ月後に<br>猫さんがLINEします。
   .usage-images.my-5
     = image_pack_tag 'media/images/undraw_Online_messaging_re_qft3.png', class: 'img-fluid'
+  .h4.my-5
+    | 次のLINEを早めに設定したい場合は<br>"Would you set to faster."<br>逆に遅めに設定したい場合は<br>"Would you set to latter."<br>と投稿してください
 .fade-in.fade-in-up.col-md-6.offset-md-3
   .h4.mt-5
     | もし働きかけを止めたいときは

--- a/spec/factories/line_groups.rb
+++ b/spec/factories/line_groups.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :line_group do
     sequence(:line_group_id) { |n| "Line_Group_Id:No#{n}" }
-    remind_at { Time.current.since(21.days) }
+    remind_at { Time.current.since(10.days) }
     status { :wait }
   end
 end


### PR DESCRIPTION
## 概要
Issue #126 
以下のエラー通知を受け取りました。
調査したところテキスト以外のメッセージ通信があった際に、
app/lines/event.rbの66行目のメソッドにおいて、
テキスト以外だと`event.message['text']`が存在せず、エラーを発生させているようです。

```rb
<Callback> 例外:NoMethodError, メッセージ:undefined method `match?' for nil:NilClass, バックトレース:["/app/app/lines/event.rb:67.....
```

上記のエラーを解消するのにnilガードを設定して、
テキスト以外のメッセージの際は、
event.message['text']に「テキスト以外の通信です」を代入して、
エラーが発生しないように修正します。

また、トップページに次のwake up投稿を早め・遅めに設定できる"おまじない"の説明を加えます。