### PR TITLE
[Fix] トップページの通知時期を設定する文言を修正する#126

### DIFF
--- a/app/views/customers/top.html.slim
+++ b/app/views/customers/top.html.slim
@@ -39,8 +39,8 @@ h1.mt-5
     | 最後の投稿から<br>3週間〜2ヶ月後に<br>猫さんがLINEします。
   .usage-images.my-5
     = image_pack_tag 'media/images/undraw_Online_messaging_re_qft3.png', class: 'img-fluid'
-  .h4.my-5
-    | 次のLINEを早めに設定したい場合は<br>"Would you set to faster."<br>逆に遅めに設定したい場合は<br>"Would you set to latter."<br>と投稿してください
+  .my-5
+    | 次の通知を早めにしたい場合は<br>"Would you set to faster."<br>逆に遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください
 .fade-in.fade-in-up.col-md-6.offset-md-3
   .h4.mt-5
     | もし働きかけを止めたいときは

--- a/app/views/customers/top.html.slim
+++ b/app/views/customers/top.html.slim
@@ -40,7 +40,7 @@ h1.mt-5
   .usage-images.my-5
     = image_pack_tag 'media/images/undraw_Online_messaging_re_qft3.png', class: 'img-fluid'
   .my-5
-    | 次の通知を早めにしたい場合は<br>"Would you set to faster."<br>逆に遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください
+    | ※次の通知を早めにしたい場合は<br>"Would you set to faster."<br>逆に遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください
 .fade-in.fade-in-up.col-md-6.offset-md-3
   .h4.mt-5
     | もし働きかけを止めたいときは


### PR DESCRIPTION
## 概要
Issue #126 
新たに追加した通知時期を設定する文言の部分が、
iPhone8より横幅が小さいスマートフォンの場合、
文字が収まりきらず、見た目が崩れた形になってしまうのを修正します。