### PR TITLE
[Fix] 通知時期を設定したい場合の説明文を修正する#133

### DIFF
--- a/app/views/customers/top.html.slim
+++ b/app/views/customers/top.html.slim
@@ -39,8 +39,10 @@ h1.mt-5
     | 最後の投稿から<br>3週間〜2ヶ月後に<br>猫さんがLINEします。
   .usage-images.my-5
     = image_pack_tag 'media/images/undraw_Online_messaging_re_qft3.png', class: 'img-fluid'
-  .my-5
-    | ※次の通知を早めにしたい場合は<br>"Would you set to faster."<br>逆に遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください
+  .mt-5.mb-3
+    | 〜 次の通知時期を設定したい場合 〜
+  .mb-5
+    | 約1ヶ月後にしたい場合は<br>"Would you set to faster."<br>もっと遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください<br>投稿時を基準に通知時期を上書きします🖍
 .fade-in.fade-in-up.col-md-6.offset-md-3
   .h4.mt-5
     | もし働きかけを止めたいときは


### PR DESCRIPTION
## 概要
Issue #133 
ユーザーが通知時期を設定できる説明の文章箇所を修正します。

方向性としては、
・ユーザーが"おまじない"を投稿した時を基準にwake up時期を更新する
・２つの設定ができることがわかる
・前半部分(おおよそ１ヶ月)、後半部分(前半部分よりももっと遅め)
の３点、特に`投稿時を基準`の部分は明記するように修正します。