### PR TITLE
[Add] ユーザーがwake up通知の間隔を設定できるようにする#135

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,9 @@ Layout/LineLength:
 RSpec/ContextWording:
   Enabled: false
 
+# 新たに追加した項目
 Metrics/MethodLength:
-  Exclude:
-    - 'app/lines/event.rb'
+  Max: 13
+
+Metrics/AbcSize:
+  Max: 21

--- a/app/controllers/operator/catch_events_controller.rb
+++ b/app/controllers/operator/catch_events_controller.rb
@@ -12,7 +12,7 @@ class Operator::CatchEventsController < Operator::BaseController
 
     # === 以下イベント毎の処理になります ===
     events = client.parse_events_from(body)
-    Event.events_processes(events, client)
+    Event.catched_events(events, client)
     'OK'
   end
 end

--- a/app/controllers/operator/line_groups_controller.rb
+++ b/app/controllers/operator/line_groups_controller.rb
@@ -42,6 +42,6 @@ class Operator::LineGroupsController < Operator::BaseController
   end
 
   def line_group_params
-    params.require(:line_group).permit(:remind_at, :status, :post_count)
+    params.require(:line_group).permit(:remind_at, :status, :post_count, :set_span)
   end
 end

--- a/app/models/line_group.rb
+++ b/app/models/line_group.rb
@@ -1,5 +1,6 @@
 class LineGroup < ApplicationRecord
-  enum status: { wait: 0, call: 1 }
+  enum status:    { wait: 0, call: 1 }
+  enum set_span:  { random: 0, faster: 1, latter: 2 }
 
   validates :line_group_id, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :remind_at,     presence: true

--- a/app/models/line_group.rb
+++ b/app/models/line_group.rb
@@ -15,24 +15,14 @@ class LineGroup < ApplicationRecord
   scope :remind_wait, -> { wait.where('remind_at <= ?', Date.current) }
   scope :remind_call, -> { call.where('remind_at <= ?', Date.current) }
 
-  def change_short_status_by_magicword(count_menbers)
-    random_number = (21..32).to_a.sample
-    passsed_day = (remind_at - updated_at.to_date).to_int
-    update!(remind_at: remind_at + (random_number - passsed_day),
-            status: :wait, post_count: post_count + 1,
-            member_count: count_menbers)
-  end
-
-  def change_long_status_by_magicword(count_menbers)
-    random_number = (49..60).to_a.sample
-    passsed_day = (remind_at - updated_at.to_date).to_int
-    update!(remind_at: remind_at + (random_number - passsed_day),
-            status: :wait, post_count: post_count + 1,
-            member_count: count_menbers)
-  end
-
   def auto_change_status(count_menbers)
-    random_number = (17..50).to_a.sample
+    random_number = if faster?
+                      (21..32).to_a.sample
+                    elsif latter?
+                      (49..60).to_a.sample
+                    else
+                      (17..60).to_a.sample
+                    end
     update!(remind_at: Date.current.since(random_number.days),
             status: :wait, post_count: post_count + 1,
             member_count: count_menbers)

--- a/app/views/customers/top.html.slim
+++ b/app/views/customers/top.html.slim
@@ -39,10 +39,14 @@ h1.mt-5
     | 最後の投稿から<br>3週間〜2ヶ月後に<br>猫さんがLINEします。
   .usage-images.my-5
     = image_pack_tag 'media/images/undraw_Online_messaging_re_qft3.png', class: 'img-fluid'
-  .mt-5.mb-3
-    | 〜 次の通知時期を設定したい場合 〜
+  .mt-5.mb-4
+    | 〜 通知時期を設定したい場合 〜
+  .mb-3
+    | 約1ヶ月後にしたい場合は<br>"Would you set to faster."
+  .mb-3
+    | もっと遅めにしたい場合は<br>"Would you set to latter."
   .mb-5
-    | 約1ヶ月後にしたい場合は<br>"Would you set to faster."<br>もっと遅めにしたい場合は<br>"Would you set to latter."<br>と投稿してください<br>投稿時を基準に通知時期を上書きします🖍
+    | デフォルトに戻したい場合は<br>"Would you set to default."<br>と投稿してください🖍
 .fade-in.fade-in-up.col-md-6.offset-md-3
   .h4.mt-5
     | もし働きかけを止めたいときは

--- a/app/views/operator/line_groups/_line_group.html.slim
+++ b/app/views/operator/line_groups/_line_group.html.slim
@@ -4,10 +4,12 @@ tr
   td
     = l(line_group.remind_at, format: :shot)
   td
-    = link_to line_group.status, operator_line_group_path(line_group), class: 'link-dark text-decoration-none'
+    = link_to line_group.status_i18n, operator_line_group_path(line_group), class: 'link-dark text-decoration-none'
   td
     = line_group.post_count
   td
     = line_group.member_count
+  td
+    = line_group.set_span_i18n
   td
     = l(line_group.updated_at, format: :shot)

--- a/app/views/operator/line_groups/edit.html.slim
+++ b/app/views/operator/line_groups/edit.html.slim
@@ -9,6 +9,9 @@ h1.mt-5
       = f.label :status
       = f.select :status, LineGroup.statuses_i18n.invert, {}, class: 'form-control rounded-pill'
     .form-group.my-5.offset-2.col-8
+      = f.label :set_span
+      = f.select :set_span, LineGroup.set_spans_i18n.invert, {}, class: 'form-control rounded-pill'
+    .form-group.my-5.offset-2.col-8
       = f.label :post_count
       = f.number_field :post_count, min: 0, max: 100_000_000, class: 'form-control rounded-pill'
     .form-group.my-5

--- a/app/views/operator/line_groups/index.html.slim
+++ b/app/views/operator/line_groups/index.html.slim
@@ -11,17 +11,19 @@ h1.mt-5
     table.table.table-striped.table-hover.text-nowrap
       thead.px-5
         tr
-          th.col-1
+          th
             | ID
-          th.col-1
+          th
             | Day
-          th.col-1
+          th
             | 状態
-          th.col-2
+          th
             | 交流
-          th.col-2
-            | 利用者
-          th.col-1
-            | 更新日
+          th
+            | 人数
+          th
+            | 期間
+          th
+            | 更新
       tbody
         = render @line_groups if @line_groups

--- a/app/views/operator/line_groups/show.html.slim
+++ b/app/views/operator/line_groups/show.html.slim
@@ -9,13 +9,16 @@ h1.mt-5
     = @line_group.remind_at
   h3.mt-5
     | 状態：
-    = @line_group.status
+    = @line_group.status_i18n
   h3.mt-5
     | 交流数：
     = @line_group.post_count
   h3.mt-5
-    | 利用者数：
+    | 人数：
     = @line_group.member_count
+  h3.mt-5
+    | 期間：
+    = @line_group.set_span_i18n
   h3.mt-5
     | 作成日：
     = l(@line_group.created_at, format: :long)

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -96,4 +96,5 @@ ja:
         remind_at: 'リマインド'
         status: '状態'
         post_count: '投稿数'
-        member_count: '利用者数'
+        member_count: '人数'
+        set_span: '期間'

--- a/config/locales/enum/ja.yml
+++ b/config/locales/enum/ja.yml
@@ -15,5 +15,9 @@ ja:
         text: 'テキスト'
     line_group:
       status:
-        wait: '呼びかけ前'
-        call: '呼びかけ実施中'
+        wait: '待機'
+        call: '呼出'
+      set_span:
+        random: '乱数'
+        faster: '早め'
+        latter: '遅め'

--- a/db/migrate/20211114025759_add_set_span_to_line_groups.rb
+++ b/db/migrate/20211114025759_add_set_span_to_line_groups.rb
@@ -1,0 +1,5 @@
+class AddSetSpanToLineGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :line_groups, :set_span, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_27_112535) do
+ActiveRecord::Schema.define(version: 2021_11_14_025759) do
 
   create_table "alarm_contents", charset: "utf8mb4", force: :cascade do |t|
     t.string "body", null: false
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2021_10_27_112535) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "post_count", default: 0, null: false
     t.integer "member_count", default: 0, null: false
+    t.integer "set_span", default: 0, null: false
     t.index ["line_group_id"], name: "index_line_groups_on_line_group_id", unique: true
   end
 


### PR DESCRIPTION
## 概要
Issue #135 
現在の"おまじない"を受けて次のwake up投稿時期を更新する形から、
ユーザーが永続的にwakue up投稿時期を設定できるように実装します。

app/lines/event.rbのリファクタリングは別途Issueにて取り組みます。