### PR TITLE
[Fix] Eventクラスの挙動がローカルとデプロイ先で異なるのを解消する

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -2,7 +2,7 @@ class Event
   # catch_events_controller#callbackが動いた際のイベント振り分けメソッド'pretreatment'を呼び出します。
   def self.catched_events(events, client)
     events.each do |event|
-      pretreatment(event, client)
+      Event.pretreatment(event, client)
     rescue StandardError => e
       group_id = Event.judge_group_or_room(event)
       error_message = "<Callback> 例外:#{e.class}, メッセージ:#{e.message}, バックトレース:#{e.backtrace}"


### PR DESCRIPTION
## 概要
Issue #135 
ローカルでは管理運営画面からset_spanの値を変更できるが、
デプロイ先では変更が反映されない状態になっているのを解消できないか試みます。

おそらくHerokuの方で上手く適応が出来ていないと思われるため、
Eventクラスのクラスメソッド名を修正して、
再度適応させ、問題の解消が出来ないか試みます。

heroku を再起動させるコマンドもありましたが、
如何せん、使っているユーザーのデータが消えてしまうのを避けたいため、
実績のあるこちら（変更を反映させる）の方法で解消を試みます。