### PR TITLE
[Fix] "おまじない"を受け取った際の返信メッセージを修正する#135

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -85,7 +85,7 @@ class Event
 
   # 設定に関する"おまじない"が投稿された際にメッセージを返します。
   def self.catched_magicword(client, line_group)
-    message = { type: 'text', text: '了解ニャ！, 次のwake up投稿をしたら、それ以降は設定した期間内でwake up投稿するニャ🐾！！' }
+    message = { type: 'text', text: '了解ニャ！, 次の投稿から設定を適応するニャ🐾！！' }
     client.push_message(line_group.line_group_id, message)
   end
 


### PR DESCRIPTION
## 概要
Issue #135 
現在設定されている返信メッセージを、
```
'了解ニャ！, 次のwake up投稿をしたら、それ以降は設定した期間内でwake up投稿するニャ🐾！！'
```
  
以下の文言へ変更します。
```
'了解ニャ！, 次の投稿から設定を適応するニャ🐾！！'
```
  
ユーザーが設定用の"おまじない"を投稿後、
メンバーの誰かが投稿を行うと、設定が適応されるため、
誤解を招かないように修正文に変更します。