### PR TITLE
[Fix] 設定確認用の文言にあるカンマを削除する#135

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -85,7 +85,7 @@ class Event
 
   # 設定に関する"おまじない"が投稿された際にメッセージを返します。
   def self.catched_magicword(client, line_group)
-    message = { type: 'text', text: '了解ニャ！, 次の投稿から設定を適応するニャ🐾！！' }
+    message = { type: 'text', text: '了解ニャ！次の投稿から設定を適応するニャ🐾！！' }
     client.push_message(line_group.line_group_id, message)
   end
 


### PR DESCRIPTION
## 概要
Issue #135 
ユーザーが設定用の"おまじない"を投稿した際に返すメッセージから「 , 」を削除します。