### PR TITLE
[Feedback_Fix] 1対1の際にメッセージが送信されても例外が発生しないようにする#141

### DIFF
--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -12,10 +12,10 @@ class Event
 
   # 上記から呼び出されて各イベントごとに、どんな操作を行うか振り分けます。
   def self.pretreatment(event, client)
-    json_data = Event.members_count(event, client)
-    count_menbers = JSON.parse(json_data.body)
     group_id = Event.judge_group_or_room(event)
     return if group_id.blank?
+    json_data = Event.members_count(event, client)
+    count_menbers = JSON.parse(json_data.body)
 
     Event.split_event(event, client, group_id, count_menbers)
   end

--- a/app/lines/event.rb
+++ b/app/lines/event.rb
@@ -14,9 +14,9 @@ class Event
   def self.pretreatment(event, client)
     group_id = Event.judge_group_or_room(event)
     return if group_id.blank?
+
     json_data = Event.members_count(event, client)
     count_menbers = JSON.parse(json_data.body)
-
     Event.split_event(event, client, group_id, count_menbers)
   end
 


### PR DESCRIPTION
## 概要
Issue #141 
LINE Bot と ユーザーが１対１の状況において、
ユーザーがメッセージを送信した際に例外が発生しているバグを修正します。

調査したところ、
app/lines/event.rbの16行目にあるbodyメソッドが機能しようとした際に、
json_dateがNilClassになっているのが原因かと思われます。