### PR TITLE
[Fix] RequestモジュールをRequestクラスに変更する#143

### DIFF
--- a/app/controllers/operator/catch_events_controller.rb
+++ b/app/controllers/operator/catch_events_controller.rb
@@ -3,13 +3,14 @@ class Operator::CatchEventsController < Operator::BaseController
   protect_from_forgery with: :null_session, only: %i[callback]
 
   require './app/lines/config/client_config'
+  require './app/lines/config/request'
   require './app/lines/line_event'
 
   def callback
     # === リクエストがLINEプラットフォームから送信されたものかを確認します ====
     client = ClientConfig.set_line_bot_client
-    body = LineEvent.request_body_read(request)
-    LineEvent.verify_request(request, client, body)
+    body = Request.request_body_read(request)
+    Request.verify_request(request, client, body)
 
     # === 以下イベント毎の処理になります ===
     events = client.parse_events_from(body)

--- a/app/lines/config/request.rb
+++ b/app/lines/config/request.rb
@@ -1,4 +1,4 @@
-module Request
+class Request
   def request_body_read(request)
     request.body.read
   end

--- a/app/lines/line_event.rb
+++ b/app/lines/line_event.rb
@@ -1,9 +1,7 @@
 class LineEvent
-  require './app/lines/config/request'
   require_relative 'message_event'
   require_relative 'join_event'
   require_relative 'leave_event'
-  extend Request
   extend MessageEvent
   extend JoinEvent
   extend LeaveEvent


### PR DESCRIPTION
## 概要
Issue #143 
先のデプロイが上手く行かなった状態が続いていますが、
ClientからRequestに対象が移ったため、
同箇所もモジュールからクラスに戻して解決を試みます。