### PR TITLE
[Fix] Prefixをディレクトリと対応した形に修正する#143

### DIFF
--- a/app/lines/events/join_event.rb
+++ b/app/lines/events/join_event.rb
@@ -1,4 +1,4 @@
-module JoinEvent
+module Events::JoinEvent
   def join_bot(client, group_id, count_menbers)
     LineEvent.create_line_group(group_id, count_menbers)
     message = { type: 'text',

--- a/app/lines/events/leave_event.rb
+++ b/app/lines/events/leave_event.rb
@@ -1,4 +1,4 @@
-module LeaveEvent
+module Events::LeaveEvent
   def leave_events(group_id, count_menbers)
     return if count_menbers['count'].to_i > 1 # "おまじない"が使用された際は、clientからの返り値は'{}'で、存在しないキーに'.to_i'を行うと'0'を返します。
 

--- a/app/lines/events/line_event.rb
+++ b/app/lines/events/line_event.rb
@@ -1,14 +1,14 @@
-class LineEvent
+class Events::LineEvent
   require './app/lines/client_config'
   require './app/lines/request'
-  require_relative 'message_event'
-  require_relative 'join_event'
-  require_relative 'leave_event'
-  extend ClientConfig
-  extend Request
-  extend MessageEvent
-  extend JoinEvent
-  extend LeaveEvent
+  require './app/lines/events/message_event'
+  require './app/lines/events/join_event'
+  require './app/lines/events/leave_event'
+  extend Events::ClientConfig
+  extend Events::Request
+  extend Events::MessageEvent
+  extend Events::JoinEvent
+  extend Events::LeaveEvent
 
   def self.catch_events(events, client)
     events.each do |event|

--- a/app/lines/events/message_event.rb
+++ b/app/lines/events/message_event.rb
@@ -1,4 +1,4 @@
-module MessageEvent
+module Events::MessageEvent
   CHANGE_SPAN_WORDS = /Would you set to faster.|Would you set to latter.|Would you set to default./
 
   def catch_message(event, client, group_id, count_menbers)


### PR DESCRIPTION
## 概要
Issue #143 
開発環境下ではZeitwerk::NameErrorが発生しない要因はまだ不明ですが、
Railsガイドを参考にPrefixをディレクトリ階層と合わせて修正します。

上記の修正によりデプロイエラーの問題解決を試みます。

Railsガイド 参考URL：
https://railsguides.jp/autoloading_and_reloading_constants.html#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E6%A7%8B%E9%80%A0