### PR TITLE
[Fix] 各LineEventに'Events::'を追記する#143

### DIFF
--- a/app/controllers/operator/catch_events_controller.rb
+++ b/app/controllers/operator/catch_events_controller.rb
@@ -6,13 +6,13 @@ class Operator::CatchEventsController < Operator::BaseController
 
   def callback
     # === リクエストがLINEプラットフォームから送信されたものかを確認します ====
-    client = LineEvent.set_line_bot_client
-    body = LineEvent.request_body_read(request)
-    LineEvent.verify_request(request, client, body)
+    client = Events::LineEvent.set_line_bot_client
+    body = Events::LineEvent.request_body_read(request)
+    Events::LineEvent.verify_request(request, client, body)
 
     # === 以下イベント毎の処理になります ===
     events = client.parse_events_from(body)
-    LineEvent.catch_events(events, client)
+    Events::LineEvent.catch_events(events, client)
     'OK'
   end
 end

--- a/app/lines/events/join_event.rb
+++ b/app/lines/events/join_event.rb
@@ -1,13 +1,13 @@
 module Events::JoinEvent
   def join_bot(client, group_id, count_menbers)
-    LineEvent.create_line_group(group_id, count_menbers)
+    Events::LineEvent.create_line_group(group_id, count_menbers)
     message = { type: 'text',
                 text: '加えてくれてありがとうニャ🌟！！最後のLINEから3週間〜2ヶ月後にwake upのLINEするニャ！！（反応が無いとすぐかも知れニャンよ⏰）末永くよろしくニャ🐱🐾' }
     client.push_message(group_id, message)
   end
 
   def join_member(client, group_id, count_menbers)
-    LineEvent.create_line_group(group_id, count_menbers)
+    Events::LineEvent.create_line_group(group_id, count_menbers)
     message = { type: 'text', text: '初めまして🌟ReLINE(https://www.cat-reline.com/)の"猫さん"っていうニャ🐱よろしくニャ🐾！！' }
     client.push_message(group_id, message)
   end

--- a/app/lines/events/line_event.rb
+++ b/app/lines/events/line_event.rb
@@ -12,33 +12,33 @@ class Events::LineEvent
 
   def self.catch_events(events, client)
     events.each do |event|
-      LineEvent.callback_action(event, client)
+      Events::LineEvent.callback_action(event, client)
     rescue StandardError => e
       group_id = Event.catch_group_or_room_id(event)
       error_message = "<Callback> 例外:#{e.class}, メッセージ:#{e.message}, バックトレース:#{e.backtrace}"
-      LineMailer.error_email(group_id, error_message).deliver_later
+      Events::LineEvent.error_email(group_id, error_message).deliver_later
     end
   end
 
   def self.callback_action(event, client)
-    group_id = LineEvent.catch_group_or_room_id(event)
+    group_id = Events::LineEvent.catch_group_or_room_id(event)
     return if group_id.blank?
 
-    json_data = LineEvent.count_group_members(event, client)
+    json_data = Events::LineEvent.count_group_members(event, client)
     count_menbers = JSON.parse(json_data.body)
-    LineEvent.branch_event_type(event, client, group_id, count_menbers)
+    Events::LineEvent.branch_event_type(event, client, group_id, count_menbers)
   end
 
   def self.branch_event_type(event, client, group_id, count_menbers)
     case event
     when Line::Bot::Event::Message
-      LineEvent.catch_message(event, client, group_id, count_menbers)
+      Events::LineEvent.catch_message(event, client, group_id, count_menbers)
     when Line::Bot::Event::Join
-      LineEvent.join_bot(client, group_id, count_menbers)
+      Events::LineEvent.join_bot(client, group_id, count_menbers)
     when Line::Bot::Event::MemberJoined
-      LineEvent.join_member(client, group_id, count_menbers)
+      Events::LineEvent.join_member(client, group_id, count_menbers)
     when Line::Bot::Event::Leave, Line::Bot::Event::MemberLeft
-      LineEvent.leave_events(group_id, count_menbers)
+      Events::LineEvent.leave_events(group_id, count_menbers)
     end
   end
 

--- a/app/lines/events/message_event.rb
+++ b/app/lines/events/message_event.rb
@@ -2,8 +2,10 @@ module Events::MessageEvent
   CHANGE_SPAN_WORDS = /Would you set to faster.|Would you set to latter.|Would you set to default./
 
   def catch_message(event, client, group_id, count_menbers)
-    LineEvent.cat_back_memory(event, client, group_id) if event.message['text'].match?('Cat sleeping on our Memory.')
-    LineEvent.change_line_group_record(event, client, group_id, count_menbers)
+    if event.message['text'].match?('Cat sleeping on our Memory.')
+      Events::LineEvent.cat_back_memory(event, client, group_id)
+    end
+    Events::LineEvent.change_line_group_record(event, client, group_id, count_menbers)
   end
 
   def cat_back_memory(event, client, group_id)
@@ -20,7 +22,7 @@ module Events::MessageEvent
     line_group = LineGroup.find_by(line_group_id: group_id)
     event.message['text'] ||= 'テキスト以外の通信です'
     if event.message['text'].match?(CHANGE_SPAN_WORDS)
-      LineEvent.change_set_span(event, line_group, client)
+      Events::LineEvent.change_set_span(event, line_group, client)
     else
       line_group.update_line_group_record(count_menbers['count'].to_i)
     end
@@ -29,13 +31,13 @@ module Events::MessageEvent
   def change_set_span(event, line_group, client)
     if event.message['text'].match?('Would you set to faster.')
       line_group.faster!
-      LineEvent.response_to_change_span_word(client, line_group)
+      Events::LineEvent.response_to_change_span_word(client, line_group)
     elsif event.message['text'].match?('Would you set to latter.')
       line_group.latter!
-      LineEvent.response_to_change_span_word(client, line_group)
+      Events::LineEvent.response_to_change_span_word(client, line_group)
     elsif event.message['text'].match?('Would you set to default.')
       line_group.random!
-      LineEvent.response_to_change_span_word(client, line_group)
+      Events::LineEvent.response_to_change_span_word(client, line_group)
     end
   end
 

--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -2,7 +2,7 @@ namespace :call_notice do
   require './app/lines/events/line_event'
   desc '短いスパンでの働きかけを行う'
   task call_reminds: :environment do
-    client = LineEvent.set_line_bot_client
+    client = Events::LineEvent.set_line_bot_client
 
     messages = [{ type: 'text', text: AlarmContent.contact.sample.body },
                 { type: 'text', text: AlarmContent.text.sample.body }]

--- a/lib/tasks/wait_notice.rake
+++ b/lib/tasks/wait_notice.rake
@@ -2,7 +2,7 @@ namespace :wait_notice do
   require './app/lines/events/line_event'
   desc '不定期な働きかけを行う'
   task wait_reminds: :environment do
-    client = LineEvent.set_line_bot_client
+    client = Events::LineEvent.set_line_bot_client
 
     messages = [{ type: 'text', text: Content.contact.sample.body },
                 { type: 'text', text: Content.free.sample.body },


### PR DESCRIPTION
## 概要
Issue #143 
各LineEventに`Events::`を追加して、
Herokuへのデプロイエラー問題の解消を試みます。