### PR TITLE
[Fix] lib/tasks/以下のコードにあるクラス名を修正する#157

### DIFF
--- a/lib/tasks/call_notice.rake
+++ b/lib/tasks/call_notice.rake
@@ -2,7 +2,7 @@ namespace :call_notice do
   require './app/lines/line_event'
   desc '短いスパンでの働きかけを行う'
   task call_reminds: :environment do
-    client = Webhook::LineEvent.set_line_bot_client
+    client = LineEvent.set_line_bot_client
 
     messages = [{ type: 'text', text: AlarmContent.contact.sample.body },
                 { type: 'text', text: AlarmContent.text.sample.body }]

--- a/lib/tasks/wait_notice.rake
+++ b/lib/tasks/wait_notice.rake
@@ -2,7 +2,7 @@ namespace :wait_notice do
   require './app/lines/line_event'
   desc '不定期な働きかけを行う'
   task wait_reminds: :environment do
-    client = Webhook::LineEvent.set_line_bot_client
+    client = LineEvent.set_line_bot_client
 
     messages = [{ type: 'text', text: Content.contact.sample.body },
                 { type: 'text', text: Content.free.sample.body },


### PR DESCRIPTION
## 概要
Issue #157 
先日のリファクタリングの際に変更した記述が原因で、
定期タスクが動いていない状態を修正します。

具体的にはlib/tasks/以下の2つのファイル内にある
クラスメソッドを実行している部分を`LineEvent`に修正します。