### PR TITLE
[Fix] message_event.rb 7行目にぼっち演算子を適応する#162

### DIFF
--- a/app/lines/message_event.rb
+++ b/app/lines/message_event.rb
@@ -4,7 +4,7 @@ module MessageEvent
   private
 
   def message_events(event, client, group_id, count_menbers)
-    cat_back_to_memory(event, client, group_id) if event.message['text'].match?('Cat sleeping on our Memory.')
+    cat_back_to_memory(event, client, group_id) if event.message['text']&.match?('Cat sleeping on our Memory.')
     update_line_group_record(event, client, group_id, count_menbers)
   end
 


### PR DESCRIPTION
## 概要
Issue #162 
エラー通知メールより、グループ内でテキストメッセージではない投稿がなされた際に、message_event.rbの7行目で`<Callback> 例外:NoMethodError, メッセージ:undefined method `match?' for nil:NilClass,`が発生していることが分かりました。

同箇所を調査したところ、
投稿内容がLINE Botを退出させる"おまじない"かを問うものであり、
"おまじない"と一致していない場合はスルーしたいので、
ぼっち演算子を適応したコードに修正します。