### PR TITLE
[Fix] models/scheduler.rb内のメソッド名を修正する

### DIFF
--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -5,7 +5,7 @@ class Scheduler
     def call_notice
       remaind_groups = LineGroup.remind_call
       messages = call_message
-      client = CatLineBot.get_line_client
+      client = CatLineBot.line_client_config
 
       wait_notice(remaind_groups, messages, client)
     end
@@ -13,7 +13,7 @@ class Scheduler
     def wait_notice
       remaind_groups = LineGroup.remind_wait
       messages = wait_messages
-      client = CatLineBot.get_line_client
+      client = CatLineBot.line_client_config
 
       wait_notice(remaind_groups, messages, client)
     end


### PR DESCRIPTION
概要
Issue #169 
models/scheduler.rb内のメソッド名を修正する。

（コミットメッセージを誤っていたようです💦すみません🙇‍♂️）