### PR TITLE
[Fix] Schedulerにあるタイプミスを修正する#169

### DIFF
--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -5,7 +5,7 @@ class Scheduler
   class << self
     def call_notice
       remaind_groups = LineGroup.remind_call
-      messages = call_message
+      messages = call_messages
       client = CatLineBot.line_client_config
 
       scheduler(remaind_groups, messages, client)


### PR DESCRIPTION
概要
Issue #169 
app/models/scheduler.rbにあったタイプミスを修正します。

（8行目の `call_message` を `call_messages` に修正）