### PR TITLE
Unify all environments to MySQL 8

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -284,7 +284,7 @@ All evaluators should:
 **Backend:**
 - Framework: Ruby on Rails 6.1.4
 - Ruby Version: 3.0.2
-- Database: MySQL2 (dev/test), PostgreSQL (production)
+- Database: MySQL 8.0+ (all environments)
 - ORM: ActiveRecord
 - Authentication: Sorcery
 - Authorization: Pundit

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -216,7 +216,7 @@ Cover all sections in the structure. If a section doesn't apply, explain why.
 
 ### 2. Be Specific
 - ❌ "We'll use a database"
-- ✅ "We'll use PostgreSQL 15 with the following schema..."
+- ✅ "We'll use MySQL 8.0 with the following schema..."
 
 ### 3. Consider Security
 Always include threat modeling and security controls.

--- a/.claude/agents/evaluators/phase1-design/design-goal-alignment-evaluator.md
+++ b/.claude/agents/evaluators/phase1-design/design-goal-alignment-evaluator.md
@@ -107,7 +107,7 @@ You evaluate **goal alignment** in design documents:
 - Are we optimizing prematurely?
 
 **Examples**:
-- ✅ Good: RESTful API with PostgreSQL for CRUD operations
+- ✅ Good: RESTful API with MySQL for CRUD operations
 - ❌ Bad: Event sourcing + CQRS + microservices for simple CRUD
 
 **Questions to Ask**:
@@ -443,7 +443,7 @@ Monolithic API:
 - S3Service (image storage)
 - Background jobs (email notifications)
 
-PostgreSQL database
+MySQL database
 Simple audit log table for history
 ```
 

--- a/.claude/agents/evaluators/phase1-design/design-maintainability-evaluator.md
+++ b/.claude/agents/evaluators/phase1-design/design-maintainability-evaluator.md
@@ -39,7 +39,7 @@ You evaluate **maintainability** in design documents:
 - Can modules be updated independently?
 
 **Examples**:
-- ✅ Good: "ProfileService depends on IUserRepository (interface), not concrete PostgresRepository"
+- ✅ Good: "ProfileService depends on IUserRepository (interface), not concrete MySQLRepository"
 - ❌ Bad: "Module A calls Module B, Module B calls Module A (circular dependency)"
 
 **Questions to Ask**:
@@ -103,7 +103,7 @@ You evaluate **maintainability** in design documents:
 
 **Examples**:
 - ✅ Good: "ProfileService accepts IUserRepository via constructor injection (mockable for testing)"
-- ❌ Bad: "ProfileService directly instantiates PostgresRepository (cannot mock)"
+- ❌ Bad: "ProfileService directly instantiates MySQLRepository (cannot mock)"
 
 **Scoring**:
 - 5.0: All modules easily testable, dependencies injectable

--- a/.claude/agents/evaluators/phase2-planner/planner-clarity-evaluator.md
+++ b/.claude/agents/evaluators/phase2-planner/planner-clarity-evaluator.md
@@ -76,7 +76,7 @@ For each task, check:
 
 **Good Examples**:
 - ✅ "Create `src/repositories/TaskRepository.ts` implementing `ITaskRepository` interface with methods: `findById(id: string): Promise<Task>`, `create(data: CreateTaskDTO): Promise<Task>`, `update(id: string, data: UpdateTaskDTO): Promise<Task>`, `delete(id: string): Promise<void>`, `findByFilters(filters: TaskFilters): Promise<Task[]>`"
-- ✅ "Add PostgreSQL migration file `migrations/001_create_tasks_table.sql` with columns: `id UUID PRIMARY KEY`, `title VARCHAR(200) NOT NULL`, `description TEXT`, `due_date TIMESTAMP`, `priority ENUM('low', 'medium', 'high')`, `status ENUM('pending', 'in_progress', 'completed')`, `created_at TIMESTAMP DEFAULT NOW()`, `updated_at TIMESTAMP DEFAULT NOW()`"
+- ✅ "Add MySQL migration file `migrations/001_create_tasks_table.sql` with columns: `id BIGINT PRIMARY KEY AUTO_INCREMENT`, `title VARCHAR(200) NOT NULL`, `description TEXT`, `due_date DATETIME`, `priority ENUM('low', 'medium', 'high')`, `status ENUM('pending', 'in_progress', 'completed')`, `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`, `updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`"
 
 **Bad Examples**:
 - ❌ "Implement repository" (What repository? What methods? What interface?)
@@ -118,7 +118,7 @@ Check if technical details are explicit:
 - ✅ File paths: `src/controllers/TaskController.ts`, `src/services/TaskService.ts`
 - ✅ Database schema: Column names, types, constraints, indexes
 - ✅ API design: `POST /api/tasks`, `GET /api/tasks/:id`, request/response DTOs
-- ✅ Technology choices: "Use PostgreSQL 14+", "Use Express.js 4.x", "Use Jest for testing"
+- ✅ Technology choices: "Use MySQL 8.0+", "Use Express.js 4.x", "Use Jest for testing"
 
 **Bad Examples**:
 - ❌ No file paths specified

--- a/.claude/agents/evaluators/phase2-planner/planner-deliverable-structure-evaluator.md
+++ b/.claude/agents/evaluators/phase2-planner/planner-deliverable-structure-evaluator.md
@@ -87,19 +87,19 @@ Focus on:
 
 **Good Specificity (Database Schema)**:
 ```
-Deliverable: PostgreSQL migration file `migrations/001_create_tasks_table.sql`
+Deliverable: MySQL migration file `migrations/001_create_tasks_table.sql`
 
 Schema:
   - Table: `tasks`
   - Columns:
-    - `id UUID PRIMARY KEY DEFAULT uuid_generate_v4()`
+    - `id BIGINT PRIMARY KEY AUTO_INCREMENT`
     - `title VARCHAR(200) NOT NULL`
     - `description TEXT`
-    - `due_date TIMESTAMP`
+    - `due_date DATETIME`
     - `priority ENUM('low', 'medium', 'high') DEFAULT 'medium'`
     - `status ENUM('pending', 'in_progress', 'completed') DEFAULT 'pending'`
-    - `created_at TIMESTAMP DEFAULT NOW()`
-    - `updated_at TIMESTAMP DEFAULT NOW()`
+    - `created_at DATETIME DEFAULT CURRENT_TIMESTAMP`
+    - `updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`
   - Indexes:
     - `CREATE INDEX idx_tasks_status ON tasks(status)`
     - `CREATE INDEX idx_tasks_due_date ON tasks(due_date)`
@@ -329,7 +329,7 @@ Score 1-5:
 - ✅ "Code coverage ≥90%"
 - ✅ "No ESLint errors or warnings"
 - ✅ "API returns 201 status code for successful creation"
-- ✅ "Migration executes without errors on PostgreSQL 14+"
+- ✅ "Migration executes without errors on MySQL 8.0+"
 - ✅ "Response time <200ms for 95th percentile"
 
 **Bad Acceptance Criteria** (subjective, vague):

--- a/.claude/agents/evaluators/phase2-planner/planner-goal-alignment-evaluator.md
+++ b/.claude/agents/evaluators/phase2-planner/planner-goal-alignment-evaluator.md
@@ -100,14 +100,14 @@ Create a mapping between requirements and tasks:
 **Non-Functional Requirements** (from design):
 1. NFR-001: API response time <200ms (95th percentile)
 2. NFR-002: System handles 1000 concurrent users
-3. NFR-003: Data persisted in PostgreSQL
+3. NFR-003: Data persisted in MySQL
 4. NFR-004: RESTful API design
 5. NFR-005: Input validation and error handling
 
 **Task Coverage**:
 - ✅ NFR-001: TASK-020 (Add database indexes for performance)
 - ✅ NFR-002: TASK-021 (Load testing and optimization)
-- ✅ NFR-003: TASK-001 (PostgreSQL migration)
+- ✅ NFR-003: TASK-001 (MySQL migration)
 - ✅ NFR-004: TASK-007, TASK-008, TASK-009 (REST endpoints)
 - ✅ NFR-005: TASK-010 (Validation middleware), TASK-011 (Error handling)
 
@@ -159,24 +159,24 @@ This is the **most important** criterion for preventing over-engineering.
 **Example 1: Database Abstraction Without Justification**
 ```
 Requirements:
-  - Use PostgreSQL for data persistence
+  - Use MySQL for data persistence
 
 Task Plan:
   - TASK-002: Define ITaskRepository interface ✅
-  - TASK-003: Implement PostgreSQLTaskRepository ✅
-  - TASK-004: Implement MySQLTaskRepository ❌ (YAGNI violation)
+  - TASK-003: Implement MySQLTaskRepository ✅
+  - TASK-004: Implement PostgreSQLTaskRepository ❌ (YAGNI violation)
   - TASK-005: Implement MongoDBTaskRepository ❌ (YAGNI violation)
   - TASK-006: Implement repository factory pattern ❌ (YAGNI violation)
 
 Issues:
-  - Requirements only mention PostgreSQL
-  - No need for MySQL or MongoDB support
+  - Requirements only mention MySQL
+  - No need for PostgreSQL or MongoDB support
   - Repository factory adds unnecessary complexity
   - 3 tasks implementing unused features (waste of effort)
 
 Recommendation:
   - Keep TASK-002 (interface for testability) ✅
-  - Keep TASK-003 (PostgreSQL implementation) ✅
+  - Keep TASK-003 (MySQL implementation) ✅
   - Remove TASK-004, TASK-005, TASK-006 (YAGNI) ❌
 ```
 
@@ -639,7 +639,7 @@ evaluation_result:
     high_priority:
       - task_ids: ["TASK-020", "TASK-021", "TASK-022"]
         description: "Implementing multi-database support (MySQL, MongoDB) not in requirements"
-        suggestion: "Remove TASK-020-022, keep only PostgreSQL (TASK-001)"
+        suggestion: "Remove TASK-020-022, keep only MySQL (TASK-001)"
       - task_ids: ["TASK-030", "TASK-031"]
         description: "Implementing task sharing and collaboration not in requirements"
         suggestion: "Remove TASK-030-031 or document as Phase 2"
@@ -658,7 +658,7 @@ evaluation_result:
   yagni_violations:
     - tasks: ["TASK-020", "TASK-021", "TASK-022"]
       description: "Multi-database support"
-      justification: "Requirements only specify PostgreSQL"
+      justification: "Requirements only specify MySQL"
       recommendation: "Remove"
     - tasks: ["TASK-040"]
       description: "Redis caching"

--- a/.claude/agents/evaluators/phase2-planner/planner-reusability-evaluator.md
+++ b/.claude/agents/evaluators/phase2-planner/planner-reusability-evaluator.md
@@ -176,16 +176,16 @@ export interface ITaskRepository {
   // ...
 }
 
-TASK-002: Implement PostgreSQLTaskRepository implements ITaskRepository
+TASK-002: Implement MySQLTaskRepository implements ITaskRepository
 TASK-003: Implement TaskService(repository: ITaskRepository)
   - Service depends on interface, not concrete implementation
-  - Can swap PostgreSQL → MySQL → MongoDB without changing service
+  - Can swap MySQL → PostgreSQL → MongoDB without changing service
 ```
 
 **Bad Abstraction**:
 ```
 TASK-003: Implement TaskService
-  - Directly uses PostgreSQL client (hardcoded dependency) ❌
+  - Directly uses MySQL client (hardcoded dependency) ❌
   - No abstraction, cannot swap database
 ```
 

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -195,7 +195,7 @@ The task plan is ready for re-evaluation.
 
 ### 1. Be Specific and Action-Oriented
 - ❌ "Work on database"
-- ✅ "Create PostgreSQL migration file for tasks table with columns: id, title, description, due_date, priority, status, created_at, updated_at"
+- ✅ "Create MySQL migration file for tasks table with columns: id, title, description, due_date, priority, status, created_at, updated_at"
 
 ### 2. Define Clear Completion Criteria
 - ❌ "Implement repository"
@@ -265,7 +265,7 @@ task_plan_metadata:
 ## 2. Task Breakdown
 
 ### TASK-001: Create Database Migration
-**Description**: Create PostgreSQL migration file for tasks table
+**Description**: Create MySQL migration file for tasks table
 
 **Dependencies**: None
 

--- a/.claude/agents/workers/database-worker-v1-self-adapting.md
+++ b/.claude/agents/workers/database-worker-v1-self-adapting.md
@@ -161,7 +161,7 @@ Output findings:
 - **Language**: TypeScript
 - **Package Manager**: npm (detected package.json)
 - **ORM**: Sequelize v6.32.1 (from package.json dependencies)
-- **Database**: PostgreSQL (from DATABASE_URL in .env)
+- **Database**: MySQL (from DATABASE_URL in .env)
 - **Migration Tool**: Sequelize migrations (detected migrations/ folder)
 
 ### Existing Code Analysis
@@ -380,7 +380,7 @@ phase2_implementation:
   detected_tech_stack:
     language: "typescript"
     orm: "sequelize"
-    database: "postgresql"
+    database: "mysql"
 ```
 
 ### Step 7: Generate Completion Report
@@ -399,7 +399,7 @@ phase2_implementation:
 
 - **Language**: TypeScript
 - **ORM**: Sequelize v6.32.1
-- **Database**: PostgreSQL
+- **Database**: MySQL
 - **Migration Tool**: Sequelize migrations
 
 **Detection Method**: Analyzed package.json, found Sequelize dependency
@@ -449,7 +449,7 @@ During execution, report:
 🔍 Step 1: Technology Stack Detection
    ✅ Detected: TypeScript (package.json found)
    ✅ Detected: Sequelize v6.32.1 (from dependencies)
-   ✅ Detected: PostgreSQL (from DATABASE_URL in .env)
+   ✅ Detected: MySQL (from DATABASE_URL in .env)
    ✅ Strategy: Use Sequelize migrations + TypeScript models
 
 📚 Step 2: Pattern Learning

--- a/Gemfile
+++ b/Gemfile
@@ -38,13 +38,10 @@ gem 'prometheus-client', '~> 4.0'
 gem 'lograge', '~> 0.14'
 gem 'request_store', '~> 1.5'
 
-group :production do
-  gem 'pg'
-end
+# Use mysql as the database for Active Record
+gem 'mysql2', '~> 0.5'
 
 group :development, :test do
-  # Use mysql as the database for Active Record
-  gem 'mysql2', '~> 0.5'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,13 +240,6 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
-    pg (1.6.2)
-    pg (1.6.2-aarch64-linux)
-    pg (1.6.2-aarch64-linux-musl)
-    pg (1.6.2-arm64-darwin)
-    pg (1.6.2-x86_64-darwin)
-    pg (1.6.2-x86_64-linux)
-    pg (1.6.2-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -472,7 +465,6 @@ DEPENDENCIES
   line-bot-api (~> 2.0)
   lograge (~> 0.14)
   mysql2 (~> 0.5)
-  pg
   prometheus-client (~> 4.0)
   propshaft
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@
 |------------|---------|---------|
 | ![Ruby](https://img.shields.io/badge/Ruby-3.4.6-CC342D?style=flat&logo=ruby&logoColor=white) | 3.4.6 | Core language |
 | ![Rails](https://img.shields.io/badge/Rails-8.1.1-CC0000?style=flat&logo=ruby-on-rails&logoColor=white) | 8.1.1 | Web framework |
-| ![MySQL](https://img.shields.io/badge/MySQL-5.7-4479A1?style=flat&logo=mysql&logoColor=white) | 0.5.x | Development database |
-| ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-blue?style=flat&logo=postgresql&logoColor=white) | Latest | Production database |
+| ![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1?style=flat&logo=mysql&logoColor=white) | 8.0+ | Database (all environments) |
 | ![LINE](https://img.shields.io/badge/LINE_Bot_API-2.0-00C300?style=flat&logo=line&logoColor=white) | 2.0 | Messaging integration |
 
 #### Core Gems
@@ -147,7 +146,7 @@ For detailed testing documentation, see [TESTING.md](TESTING.md).
 - Ruby 3.4.6
 - Rails 8.1.1
 - Node.js 20+ and npm
-- MySQL 5.7+ (development) or PostgreSQL (production)
+- MySQL 8.0+
 - LINE Developer Account ([Create one here](https://developers.line.biz/))
 
 ### Installation

--- a/config/database.yml
+++ b/config/database.yml
@@ -51,6 +51,4 @@ test:
 #
 production:
   <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
+  database: <%= ENV.fetch("DB_NAME", "reline_production") %>


### PR DESCRIPTION
## Summary

- Remove `pg` gem from production group and move `mysql2` gem to all environments
- Update `config/database.yml` production config to use MySQL instead of PostgreSQL
- Update documentation (README.md, CLAUDE.md, EDAF agents) to reflect MySQL 8.0+ usage

## Changes

### Configuration
- **Gemfile**: Removed `pg` gem, moved `mysql2` to global scope
- **database.yml**: Production now inherits from default MySQL config

### Documentation
- **README.md**: Updated tech stack badges and prerequisites
- **.claude/CLAUDE.md**: Updated database description
- **EDAF agents**: Updated examples from PostgreSQL to MySQL

## Motivation

This change eliminates environment parity issues between development/test (MySQL) and production (PostgreSQL), reducing SQL compatibility risks and simplifying the development workflow.

## Test plan

- [x] Verify `bundle install` succeeds
- [x] Verify no PostgreSQL references remain in configuration files
- [x] CI tests pass with MySQL configuration

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)