### PR TITLE
fix: Remove broken links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Keep your LINE groups alive with our friendly cat companion!**
 
-[🌐 Visit Website](https://www.cat-reline.com/) | [📖 Documentation](https://qiita.com/Tsuchiy_2/items/4e8c038f58c23b57b0be) | [🚀 Getting Started](#-getting-started)
+[🚀 Getting Started](#-getting-started)
 
 ![Cat Mascot](/readme-images/cat.webp)
 


### PR DESCRIPTION
## Summary
- README.mdからリンク切れになっていたWebサイトとドキュメントのリンクを削除
- Getting Startedへのリンクは維持

## Changes
- Removed `🌐 Visit Website` link (https://www.cat-reline.com/ - 404)
- Removed `📖 Documentation` link (broken Qiita link)
- Kept `🚀 Getting Started` internal anchor link

## Test plan
- [x] README.mdが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)