### PR TITLE
fix: Docker Compose startup issues with JS watch and Puma binding

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
-js: yarn build --watch
+web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0
+js: npm run watch:js
 css: yarn watch:css

--- a/README.md
+++ b/README.md
@@ -148,8 +148,59 @@ For detailed testing documentation, see [TESTING.md](TESTING.md).
 - Node.js 20+ and npm
 - MySQL 8.0+
 - LINE Developer Account ([Create one here](https://developers.line.biz/))
+- Docker & Docker Compose (optional, for containerized development)
 
-### Installation
+### 🐳 Docker Setup (Recommended)
+
+The easiest way to get started is using Docker:
+
+1. **Clone the repository**
+
+```bash
+git clone https://github.com/yourusername/cat_salvages_the_relationship.git
+cd cat_salvages_the_relationship
+```
+
+2. **Configure environment variables**
+
+Create a `.env` file or set up `config/credentials.yml.enc` with your LINE API keys.
+
+3. **Start the application**
+
+```bash
+docker compose up
+```
+
+This will:
+- Start MySQL 8.0 database container
+- Build and start the Rails application
+- Run the app at [http://localhost:3000](http://localhost:3000)
+
+**Useful Docker commands:**
+
+```bash
+# Start in detached mode
+docker compose up -d
+
+# View logs
+docker compose logs -f web
+
+# Run Rails console
+docker compose exec web bin/rails console
+
+# Run tests
+docker compose exec web bundle exec rspec
+
+# Stop containers
+docker compose down
+
+# Rebuild after Gemfile/package.json changes
+docker compose build
+```
+
+---
+
+### Local Installation (Alternative)
 
 1. **Clone the repository**
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "npm run build:app && npm run build:serviceworker",
     "build:app": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
     "build:serviceworker": "esbuild app/javascript/serviceworker.js --bundle --sourcemap --format=iife --outfile=public/serviceworker.js --target=es2020",
+    "watch:js": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets --watch",
     "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "npm run build:css:compile && npm run build:css:prefix",


### PR DESCRIPTION
## Summary

- Fix Docker Compose containers failing to start due to JS watch process exiting immediately
- Fix Puma binding to localhost only, preventing external container access
- Add Docker setup documentation to README.md

## Root Causes

### 1. JS watch exits immediately
`yarn build --watch` doesn't pass `--watch` to esbuild, causing immediate exit and foreman terminating all processes.

### 2. Puma binds to 127.0.0.1
Default Puma binding prevents access from outside the container.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `watch:js` script with `--watch` flag |
| `Procfile.dev` | Use `npm run watch:js`, add `-b 0.0.0.0` to Puma |
| `README.md` | Add Docker setup documentation |

## Test plan

- [ ] Run `docker compose up` and verify containers stay running
- [ ] Access http://localhost:3000 from host machine
- [ ] Verify JS hot reload works when modifying files
- [ ] Verify CSS hot reload works when modifying files

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)