### PR TITLE
docs: READMEを日本語化しDocker環境に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,344 +1,275 @@
 <div align="center">
 
-# 🐱 ReLINE - Cat Messenger Bot
+# 🐱 ReLINE - 猫メッセンジャーBot
 
 [![Ruby](https://img.shields.io/badge/Ruby-3.4.6-CC342D?style=flat&logo=ruby&logoColor=white)](https://www.ruby-lang.org/)
 [![Rails](https://img.shields.io/badge/Rails-8.1.1-CC0000?style=flat&logo=ruby-on-rails&logoColor=white)](https://rubyonrails.org/)
 [![LINE](https://img.shields.io/badge/LINE-Messaging_API-00C300?style=flat&logo=line&logoColor=white)](https://developers.line.biz/en/services/messaging-api/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Keep your LINE groups alive with our friendly cat companion!**
+**かわいい猫の仲間と一緒に、LINEグループを活性化しましょう！**
 
-[🚀 Getting Started](#-getting-started)
+[🚀 はじめに](#-はじめに)
 
-![Cat Mascot](/readme-images/cat.webp)
+![猫マスコット](/readme-images/cat.webp)
 
 </div>
 
 ---
 
-## 📖 Overview
+## 📖 概要
 
-**ReLINE** is an intelligent LINE bot service that revitalizes dormant group chats by sending engaging messages from our friendly cat mascot. When a LINE group becomes inactive for a certain period, the bot automatically sends conversation starters to re-engage members and restore community interaction.
+**ReLINE**は、休眠状態のグループチャットを活性化するインテリジェントなLINE Botサービスです。かわいい猫のマスコットが魅力的なメッセージを送信します。LINEグループが一定期間非アクティブになると、Botが自動的に会話のきっかけとなるメッセージを送信し、メンバーの再参加とコミュニティの交流を促進します。
 
-### 🎯 Key Features
+### 🎯 主な機能
 
-- 🤖 **Automated Group Monitoring** - Tracks group activity and detects dormancy
-- 💬 **Smart Message Delivery** - Sends contextual conversation starters at optimal times
-- 📊 **Admin Dashboard** - Manage groups and monitor engagement metrics
-- 🔐 **Secure Authentication** - Protected admin access with role-based permissions
-- 📈 **Analytics & Insights** - Track conversation revival success rates
+- 🤖 **自動グループ監視** - グループの活動を追跡し、休眠状態を検出
+- 💬 **スマートメッセージ配信** - 最適なタイミングで文脈に応じた会話のきっかけを送信
+- 📊 **管理ダッシュボード** - グループの管理とエンゲージメント指標の監視
+- 🔐 **セキュアな認証** - ロールベースの権限による保護された管理者アクセス
+- 📈 **分析とインサイト** - 会話復活の成功率を追跡
 
 ---
 
-## 🎬 How It Works
+## 🎬 使い方
 
-![Usage Example](/readme-images/example.webp)
+![使用例](/readme-images/example.webp)
 
 <div align="center">
 
-### User Interface Gallery
+### ユーザーインターフェースギャラリー
 
 </div>
 
-| Web Landing Page | QR Code Screen | LINE App Integration |
+| Webランディングページ | QRコード画面 | LINEアプリ連携 |
 |:---:|:---:|:---:|
-| ![Web Top Page](/readme-images/web-top-page.webp) | ![QR Code](/readme-images/qr-code.webp) | ![LINE Page](/readme-images/line-page.webp) |
-| Main landing page with mascot and "Add Friend" button | QR code display for desktop users | Mobile app integration view |
+| ![Webトップページ](/readme-images/web-top-page.webp) | ![QRコード](/readme-images/qr-code.webp) | ![LINEページ](/readme-images/line-page.webp) |
+| マスコットと「友だち追加」ボタンのあるメインランディングページ | PC用QRコード表示 | モバイルアプリ連携画面 |
 
 ---
 
-## 🛠 Tech Stack
+## 🛠 技術スタック
 
-### Backend
+### バックエンド
 
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| ![Ruby](https://img.shields.io/badge/Ruby-3.4.6-CC342D?style=flat&logo=ruby&logoColor=white) | 3.4.6 | Core language |
-| ![Rails](https://img.shields.io/badge/Rails-8.1.1-CC0000?style=flat&logo=ruby-on-rails&logoColor=white) | 8.1.1 | Web framework |
-| ![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1?style=flat&logo=mysql&logoColor=white) | 8.0+ | Database (all environments) |
-| ![LINE](https://img.shields.io/badge/LINE_Bot_API-2.0-00C300?style=flat&logo=line&logoColor=white) | 2.0 | Messaging integration |
+| 技術 | バージョン | 用途 |
+|------|-----------|------|
+| ![Ruby](https://img.shields.io/badge/Ruby-3.4.6-CC342D?style=flat&logo=ruby&logoColor=white) | 3.4.6 | コア言語 |
+| ![Rails](https://img.shields.io/badge/Rails-8.1.1-CC0000?style=flat&logo=ruby-on-rails&logoColor=white) | 8.1.1 | Webフレームワーク |
+| ![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1?style=flat&logo=mysql&logoColor=white) | 8.0+ | データベース（全環境） |
+| ![LINE](https://img.shields.io/badge/LINE_Bot_API-2.0-00C300?style=flat&logo=line&logoColor=white) | 2.0 | メッセージング連携 |
 
-#### Core Gems
+#### コアGems
 
-- **Authentication** - Rails 8 `has_secure_password` - Secure admin login with bcrypt
-- **Authorization** - `pundit` - Policy-based access control
-- **Rate Limiting** - `rack-attack` - Brute force protection and request throttling
-- **Messaging** - `line-bot-api` - LINE Messaging API integration
-- **Monitoring** - `prometheus-client` - Metrics collection and monitoring
-- **Logging** - `lograge` - Structured logging for production
+- **認証** - Rails 8 `has_secure_password` - bcryptによるセキュアな管理者ログイン
+- **認可** - `pundit` - ポリシーベースのアクセス制御
+- **レート制限** - `rack-attack` - ブルートフォース攻撃対策とリクエストスロットリング
+- **メッセージング** - `line-bot-api` - LINE Messaging API連携
+- **監視** - `prometheus-client` - メトリクス収集と監視
+- **ログ** - `lograge` - 本番環境向け構造化ログ
 
-#### Development & Testing
+#### 開発・テスト
 
-- **Testing Framework** - `rspec-rails` - Comprehensive test suite
-- **Browser Automation** - `selenium-webdriver` - System testing with headless Chrome
-- **Code Quality** - `rubocop` with Rails, Performance, and RSpec extensions
-- **Test Data** - `factory_bot_rails`, `faker` - Factory and fixture generation
-- **Security** - `brakeman`, `bundler-audit` - Security vulnerability scanning
-- **Coverage** - `simplecov` - Test coverage analysis (88% threshold)
+- **テストフレームワーク** - `rspec-rails` - 包括的なテストスイート
+- **ブラウザ自動化** - `selenium-webdriver` - ヘッドレスChromeによるシステムテスト
+- **コード品質** - `rubocop`（Rails、Performance、RSpec拡張付き）
+- **テストデータ** - `factory_bot_rails`、`faker` - ファクトリとフィクスチャ生成
+- **セキュリティ** - `brakeman`、`bundler-audit` - セキュリティ脆弱性スキャン
+- **カバレッジ** - `simplecov` - テストカバレッジ分析（88%閾値）
 
-### Frontend
+### フロントエンド
 
-| Technology | Purpose |
-|------------|---------|
-| ![Bootstrap](https://img.shields.io/badge/Bootstrap-5.3.8-7952B3?style=flat&logo=bootstrap&logoColor=white) | Responsive UI framework |
-| ![JavaScript](https://img.shields.io/badge/JavaScript-ES6+-F7DF1E?style=flat&logo=javascript&logoColor=black) | Client-side interactivity |
-| ![Stimulus](https://img.shields.io/badge/Stimulus-Hotwire-FF6600?style=flat) | JavaScript framework |
-| ![Turbo](https://img.shields.io/badge/Turbo-Hotwire-FF6600?style=flat) | SPA-like navigation |
+| 技術 | 用途 |
+|------|------|
+| ![Bootstrap](https://img.shields.io/badge/Bootstrap-5.3.8-7952B3?style=flat&logo=bootstrap&logoColor=white) | レスポンシブUIフレームワーク |
+| ![JavaScript](https://img.shields.io/badge/JavaScript-ES6+-F7DF1E?style=flat&logo=javascript&logoColor=black) | クライアントサイドインタラクティビティ |
+| ![Stimulus](https://img.shields.io/badge/Stimulus-Hotwire-FF6600?style=flat) | JavaScriptフレームワーク |
+| ![Turbo](https://img.shields.io/badge/Turbo-Hotwire-FF6600?style=flat) | SPA風ナビゲーション |
 
-#### Asset Pipeline
+#### アセットパイプライン
 
-- **JS Bundling** - `jsbundling-rails` with esbuild
-- **CSS Bundling** - `cssbundling-rails` with Bootstrap
-- **Asset Serving** - `propshaft` - Modern asset pipeline
-
----
-
-## 📐 Architecture
-
-### Database Schema
-
-![ER Diagram](/readme-images/reline-er.webp)
-
-### Infrastructure
-
-![Infrastructure Diagram](/readme-images/reline-infra.webp)
-
-### Event Processing Architecture
-
-![LINE Bot Reaction Flow](/readme-images/line-bot-reaction.webp)
-
-Our event processing system elegantly handles multiple LINE Messaging API events through a single endpoint, utilizing:
-
-- **Service Objects** - Dedicated service classes for each event type
-- **Strategy Pattern** - Dynamic event handler selection
-- **Dry Controllers** - Minimal controller logic with delegated responsibilities
-- **Rubocop Compliant** - Adheres to strict style guidelines without sacrificing readability
+- **JSバンドル** - `jsbundling-rails`（esbuild使用）
+- **CSSバンドル** - `cssbundling-rails`（Bootstrap使用）
+- **アセット配信** - `propshaft` - モダンなアセットパイプライン
 
 ---
 
-## 📊 Test Coverage
+## 📐 アーキテクチャ
 
-![Test Coverage](/readme-images/coverage.webp)
+### データベーススキーマ
 
-- **Model Specs** - Comprehensive unit tests for business logic
-- **System Specs** - End-to-end integration testing with **Selenium**
-- **RSpec** - Primary testing framework
-- **SimpleCov** - Coverage reporting (88% threshold)
-- **Selenium** - Browser automation with headless Chrome
+![ER図](/readme-images/reline-er.webp)
 
-### Testing Infrastructure
+### インフラストラクチャ
 
-Our testing infrastructure uses Selenium with headless Chrome for system tests, providing:
-- 🚀 **Headless Chrome** - Fast execution in CI/CD environments
-- 📸 **Automatic Screenshots** - Captured on test failures
-- 🔄 **Capybara Integration** - Seamless Rails integration
-- 🌐 **Cross-Platform** - Consistent behavior across environments
+![インフラ構成図](/readme-images/reline-infra.webp)
 
-For detailed testing documentation, see [TESTING.md](TESTING.md).
+### イベント処理アーキテクチャ
+
+![LINE Botリアクションフロー](/readme-images/line-bot-reaction.webp)
+
+イベント処理システムは、単一のエンドポイントで複数のLINE Messaging APIイベントをエレガントに処理します：
+
+- **サービスオブジェクト** - 各イベントタイプ専用のサービスクラス
+- **ストラテジーパターン** - 動的なイベントハンドラー選択
+- **シンコントローラー** - 責務を委譲した最小限のコントローラーロジック
+- **Rubocop準拠** - 可読性を損なうことなく厳格なスタイルガイドラインに準拠
 
 ---
 
-## 🚀 Getting Started
+## 📊 テストカバレッジ
 
-### Prerequisites
+![テストカバレッジ](/readme-images/coverage.webp)
 
-- Ruby 3.4.6
-- Rails 8.1.1
-- Node.js 20+ and npm
-- MySQL 8.0+
-- LINE Developer Account ([Create one here](https://developers.line.biz/))
-- Docker & Docker Compose (optional, for containerized development)
+- **モデルスペック** - ビジネスロジックの包括的なユニットテスト
+- **システムスペック** - **Selenium**によるエンドツーエンド統合テスト
+- **RSpec** - 主要テストフレームワーク
+- **SimpleCov** - カバレッジレポート（88%閾値）
+- **Selenium** - ヘッドレスChromeによるブラウザ自動化
 
-### 🐳 Docker Setup (Recommended)
+### テストインフラストラクチャ
 
-The easiest way to get started is using Docker:
+テストインフラストラクチャは、システムテストにSeleniumとヘッドレスChromeを使用し、以下を提供します：
+- 🚀 **ヘッドレスChrome** - CI/CD環境での高速実行
+- 📸 **自動スクリーンショット** - テスト失敗時にキャプチャ
+- 🔄 **Capybara連携** - シームレスなRails統合
+- 🌐 **クロスプラットフォーム** - 環境間で一貫した動作
 
-1. **Clone the repository**
+詳細なテストドキュメントは[TESTING.md](TESTING.md)を参照してください。
+
+---
+
+## 🚀 はじめに
+
+### 前提条件
+
+- Docker & Docker Compose
+- LINE開発者アカウント（[こちらで作成](https://developers.line.biz/)）
+
+### 🐳 Dockerセットアップ
+
+1. **リポジトリをクローン**
 
 ```bash
 git clone https://github.com/yourusername/cat_salvages_the_relationship.git
 cd cat_salvages_the_relationship
 ```
 
-2. **Configure environment variables**
+2. **環境変数を設定**
 
-Create a `.env` file or set up `config/credentials.yml.enc` with your LINE API keys.
+`.env`ファイルを作成するか、`config/credentials.yml.enc`にLINE APIキーを設定します。
 
-3. **Start the application**
+3. **アプリケーションを起動**
 
 ```bash
 docker compose up
 ```
 
-This will:
-- Start MySQL 8.0 database container
-- Build and start the Rails application
-- Run the app at [http://localhost:3000](http://localhost:3000)
+これにより：
+- MySQL 8.0データベースコンテナが起動
+- Railsアプリケーションがビルドされ起動
+- [http://localhost:3000](http://localhost:3000)でアプリが実行
 
-**Useful Docker commands:**
+**便利なDockerコマンド：**
 
 ```bash
-# Start in detached mode
+# バックグラウンドで起動
 docker compose up -d
 
-# View logs
+# ログを表示
 docker compose logs -f web
 
-# Run Rails console
+# Railsコンソールを実行
 docker compose exec web bin/rails console
 
-# Run tests
+# テストを実行
 docker compose exec web bundle exec rspec
 
-# Stop containers
+# コンテナを停止
 docker compose down
 
-# Rebuild after Gemfile/package.json changes
+# Gemfile/package.json変更後に再ビルド
 docker compose build
+
+# テストを実行
+docker compose exec web bundle exec rspec
+
+# カバレッジ付きでテストを実行
+docker compose exec web bash -c "COVERAGE=true bundle exec rspec"
+
+# システムテストのみを実行
+docker compose exec web bundle exec rspec spec/system
+
+# コード品質チェック
+docker compose exec web bundle exec rubocop
+
+# セキュリティ監査
+docker compose exec web bundle exec brakeman
+docker compose exec web bundle exec bundler-audit
+
+# ルートを表示
+docker compose exec web bin/rails routes
 ```
+
+詳細なテストコマンドとオプションは[TESTING.md](TESTING.md)を参照してください。
 
 ---
 
-### Local Installation (Alternative)
+## 🎓 技術的ハイライト
 
-1. **Clone the repository**
+### 課題：イベント駆動アーキテクチャ
 
-```bash
-git clone https://github.com/yourusername/cat_salvages_the_relationship.git
-cd cat_salvages_the_relationship
-```
+最も重要な課題の1つは、LINE Messaging API向けのクリーンなイベント駆動アーキテクチャの実装でした。単一のWebhookエンドポイントが複数のイベントタイプ（メッセージ、フォロー、参加、退出など）を受信し、それぞれに異なる処理ロジックが必要でした。
 
-2. **Install dependencies**
+**解決策：**
 
-```bash
-bundle install
-npm install
-```
+以下を実現するサービス指向アーキテクチャを実装しました：
+- イベント処理ロジックを専用のサービスオブジェクトに分離
+- サービスに委譲するシンコントローラーを維持
+- 拡張性のためのポリモーフィックなイベントプロセッサを使用
+- SOLIDの原則とRubocop標準に準拠
 
-3. **Configure environment variables**
-
-Create a `config/credentials.yml.enc` file or set environment variables:
-
-```bash
-# LINE Messaging API
-LINE_CHANNEL_SECRET=your_channel_secret
-LINE_CHANNEL_TOKEN=your_channel_token
-
-# Database (development uses MySQL by default)
-DATABASE_URL=mysql2://username:password@localhost/reline_development
-```
-
-> ⚠️ **Note**: The `master.key` file is managed by the development team. For personal testing, generate a new key or use environment variables.
-
-4. **Setup database**
-
-```bash
-bin/rails db:create
-bin/rails db:migrate
-bin/rails db:seed
-```
-
-5. **Build assets**
-
-```bash
-npm run build
-npm run build:css
-```
-
-6. **Start the server**
-
-```bash
-bin/rails server
-```
-
-Visit [http://localhost:3000](http://localhost:3000) to see the application.
-
-### Available Commands
-
-```bash
-# Run tests
-bundle exec rspec
-
-# Run tests with coverage
-COVERAGE=true bundle exec rspec
-
-# Run system tests only (with Playwright)
-bundle exec rspec spec/system
-
-# Check code quality
-bundle exec rubocop
-
-# Security audit
-bundle exec brakeman
-bundle exec bundler-audit
-
-# View routes
-bin/rails routes
-
-# Rails console
-bin/rails console
-```
-
-For detailed testing commands and options, see [TESTING.md](TESTING.md).
+このアーキテクチャは以下を通じて進化しました：
+- 経験豊富なエンジニアからのフィードバック
+- 「パーフェクトRuby on Rails」のベストプラクティスの学習
+- Fat ModelとFat Controllerを避けるための反復的なリファクタリング
+- 厳格なRubocop準拠
 
 ---
 
-## 🎓 Technical Highlights
+## 📚 リソース
 
-### Challenge: Event-Driven Architecture
+### ブログ記事
 
-One of the most significant challenges was implementing a clean event-driven architecture for the LINE Messaging API. A single webhook endpoint receives multiple event types (messages, follows, joins, leaves, etc.), each requiring different processing logic.
+- 📝 [RailsでLINE Botを構築する - 初心者向けガイド](https://qiita.com/Tsuchiy_2/items/4e8c038f58c23b57b0be)（日本語）
 
-**Solution:**
+### ドキュメント
 
-We implemented a service-oriented architecture that:
-- Separates event handling logic into dedicated service objects
-- Maintains thin controllers that delegate to services
-- Uses polymorphic event processors for extensibility
-- Adheres to SOLID principles and Rubocop standards
-
-This architecture evolved through:
-- Feedback from experienced engineers
-- Study of "Perfect Ruby on Rails" best practices
-- Iterative refactoring to avoid Fat Models and Fat Controllers
-- Rigorous Rubocop compliance
+- [LINE Messaging APIドキュメント](https://developers.line.biz/ja/docs/messaging-api/)
+- [Rails 8.1ガイド](https://railsguides.jp/)
+- [Ruby 3.4ドキュメント](https://docs.ruby-lang.org/ja/3.4.0/)
 
 ---
 
-## 📚 Resources
+## 🤝 コントリビューション
 
-### Blog Posts
+コントリビューションを歓迎します！お気軽にプルリクエストを送信してください。
 
-- 📝 [Building a LINE Bot with Rails - A Beginner's Guide](https://qiita.com/Tsuchiy_2/items/4e8c038f58c23b57b0be) (Japanese)
-
-### Documentation
-
-- [LINE Messaging API Documentation](https://developers.line.biz/en/docs/messaging-api/)
-- [Rails 8.1 Guides](https://guides.rubyonrails.org/)
-- [Ruby 3.4 Documentation](https://docs.ruby-lang.org/en/3.4.0/)
+1. リポジトリをフォーク
+2. フィーチャーブランチを作成（`git checkout -b feature/amazing-feature`）
+3. 変更をコミット（`git commit -m 'Add some amazing feature'`）
+4. ブランチにプッシュ（`git push origin feature/amazing-feature`）
+5. プルリクエストを開く
 
 ---
 
-## 🤝 Contributing
+## 📄 ライセンス
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+このプロジェクトはMITライセンスの下でライセンスされています。詳細は[LICENSE](LICENSE)ファイルを参照してください。
 
 ---
 
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
-
-## 👤 Author
+## 👤 作者
 
 **Tsuchiya Yuji**
 
@@ -349,8 +280,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 <div align="center">
 
-**Made with ❤️ and Ruby**
+**Rubyと愛情を込めて開発しました**
 
-⭐ Star this repository if you find it helpful!
+⭐ このリポジトリが役に立ったらスターをお願いします！
 
 </div>


### PR DESCRIPTION
  - README.mdを全面的に日本語へ翻訳
  - 開発環境をDockerのみに統一し、ローカルインストール手順を削除
  - 前提条件をDocker & Docker Composeに簡素化
  - 全コマンドをdocker compose exec形式に変更