### PR TITLE
test: テストカバレッジを行・ブランチともに100%へ引き上げ

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,4 +268,4 @@ docker compose exec web bin/rails routes
 **Tsuchiya Yuji**
 
 - GitHub: [@Tsuchiya2](https://github.com/Tsuchiya2)
-- Qiita: [@Tsuchiy_2](https://qiita.com/Tsuchiy_2)
+- Qiita: [@Tsuchiya2](https://qiita.com/Tsuchiya2)

--- a/app/services/prometheus_metrics.rb
+++ b/app/services/prometheus_metrics.rb
@@ -17,7 +17,7 @@ module PrometheusMetrics
     def track_webhook_duration(event_type, duration)
       return unless defined?(WEBHOOK_DURATION)
 
-      WEBHOOK_DURATION.observe({ event_type: event_type }, duration)
+      WEBHOOK_DURATION.observe(duration, labels: { event_type: event_type })
     end
 
     # Track webhook request
@@ -61,7 +61,7 @@ module PrometheusMetrics
       return unless defined?(LINE_API_CALLS_TOTAL) && defined?(LINE_API_DURATION)
 
       LINE_API_CALLS_TOTAL.increment(labels: { method: method, status: status })
-      LINE_API_DURATION.observe({ method: method }, duration)
+      LINE_API_DURATION.observe(duration, labels: { method: method })
     end
 
     # Track message send result
@@ -79,7 +79,7 @@ module PrometheusMetrics
     def update_group_count(count)
       return unless defined?(LINE_GROUPS_TOTAL)
 
-      LINE_GROUPS_TOTAL.set({}, count)
+      LINE_GROUPS_TOTAL.set(count)
     end
   end
 end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'prometheus/client'
+require 'prometheus/client/formats/text'
 
 prometheus = Prometheus::Client.registry
 

--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Channel, type: :channel do
+  it 'inherits from ActionCable::Channel::Base' do
+    expect(described_class.ancestors).to include(ActionCable::Channel::Base)
+  end
+end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  it 'inherits from ActionCable::Connection::Base' do
+    expect(described_class.ancestors).to include(ActionCable::Connection::Base)
+  end
+end

--- a/spec/controllers/api/metrics_controller_value_spec.rb
+++ b/spec/controllers/api/metrics_controller_value_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the defensive nil-value guard in valid_metric_entry?, which is
+# otherwise unreachable because build_metric_entries coerces values with `to_d`.
+RSpec.describe Api::MetricsController, type: :controller do
+  describe 'POST #create' do
+    it 'rejects an entry whose built value is nil' do
+      allow(controller).to receive(:build_metric_entries).and_return(
+        [{ name: 'broken', value: nil, unit: nil, tags: nil, trace_id: nil, created_at: Time.current }]
+      )
+
+      post :create, params: { metrics: [{ name: 'broken', value: 1 }] }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['error']).to eq('Invalid metric entries')
+    end
+  end
+end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HealthController, type: :controller do
+  def json
+    JSON.parse(response.body)
+  end
+
+  # Force the DB connectivity probe (`SELECT 1`) to fail while leaving every
+  # other query working, so `database_connected?` exercises its rescue branch.
+  def stub_database_down
+    allow(ActiveRecord::Base.connection).to receive(:execute).and_call_original
+    allow(ActiveRecord::Base.connection).to receive(:execute)
+      .with('SELECT 1')
+      .and_raise(ActiveRecord::StatementInvalid.new('database unavailable'))
+  end
+
+  describe 'GET #show' do
+    it 'returns ok' do
+      get :show
+
+      expect(response).to have_http_status(:ok)
+      expect(json['status']).to eq('ok')
+      expect(json['timestamp']).to be_present
+      expect(json).to have_key('version')
+    end
+  end
+
+  describe 'GET #deep' do
+    context 'when all dependencies are healthy' do
+      before do
+        allow(controller).to receive(:`).and_return('/dev/root 20G 10G 10G 50% /')
+      end
+
+      it 'returns ok with database and disk_space checks' do
+        get :deep
+
+        expect(response).to have_http_status(:ok)
+        expect(json['status']).to eq('ok')
+        expect(json['checks']['database']['status']).to eq('ok')
+        expect(json['checks']['database']['response_time_ms']).to be_present
+        expect(json['checks']['disk_space']['status']).to eq('ok')
+      end
+    end
+
+    context 'when the database is unavailable' do
+      before do
+        stub_database_down
+        allow(controller).to receive(:`).and_return('/dev/root 20G 10G 10G 50% /')
+      end
+
+      it 'returns service_unavailable and reports the database as failed' do
+        get :deep
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['status']).to eq('degraded')
+        expect(json['checks']['database']['status']).to eq('error')
+      end
+    end
+
+    context 'when measuring the database response time raises' do
+      before do
+        # database_connected? returns true against the real (up) test DB, so only
+        # measure_database_response_time is stubbed to trigger check_database's rescue.
+        allow(controller).to receive(:measure_database_response_time).and_raise(StandardError.new('timeout'))
+        allow(controller).to receive(:`).and_return('/dev/root 20G 10G 10G 50% /')
+      end
+
+      it 'rescues the error and reports it in the database check' do
+        get :deep
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['checks']['database']['status']).to eq('error')
+        expect(json['checks']['database']['message']).to eq('timeout')
+      end
+    end
+
+    context 'when disk space is low' do
+      before do
+        allow(controller).to receive(:`).and_return('/dev/root 20G 19G 1G 95% /')
+      end
+
+      it 'reports the disk_space check as a warning' do
+        get :deep
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['checks']['disk_space']['status']).to eq('warning')
+        expect(json['checks']['disk_space']['usage_percent']).to eq(95)
+      end
+    end
+
+    context 'when the disk space check raises' do
+      before do
+        allow(controller).to receive(:`).and_raise(StandardError.new('df failed'))
+      end
+
+      it 'rescues the error and reports it in the disk_space check' do
+        get :deep
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['checks']['disk_space']['status']).to eq('error')
+        expect(json['checks']['disk_space']['message']).to eq('df failed')
+      end
+    end
+  end
+
+  describe 'GET #ready' do
+    context 'when the database is connected' do
+      it 'returns ready' do
+        get :ready
+
+        expect(response).to have_http_status(:ok)
+        expect(json['status']).to eq('ready')
+      end
+    end
+
+    context 'when the database is not connected' do
+      before { stub_database_down }
+
+      it 'returns not_ready' do
+        get :ready
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json['status']).to eq('not_ready')
+        expect(json['reason']).to eq('database_unavailable')
+      end
+    end
+  end
+end

--- a/spec/controllers/operator/line_groups_controller_spec.rb
+++ b/spec/controllers/operator/line_groups_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operator::LineGroupsController, type: :controller do
+  let(:operator) { create(:operator) }
+
+  before { session[:operator_id] = operator.id }
+
+  describe 'DELETE #destroy' do
+    it 'destroys the line group' do
+      group = create(:line_group)
+
+      expect do
+        delete :destroy, params: { id: group.id }
+      end.to change(LineGroup, :count).by(-1)
+    end
+
+    it 'redirects to the line groups index with a success message' do
+      group = create(:line_group)
+
+      delete :destroy, params: { id: group.id }
+
+      expect(response).to redirect_to(operator_line_groups_path)
+      expect(flash[:success]).to eq('LINEグループ情報を削除しました。')
+    end
+  end
+
+  describe 'authentication with an invalid session' do
+    it 'resets the session and redirects to login when the operator lookup raises RecordNotFound' do
+      session[:operator_id] = 999
+      allow(Operator).to receive(:find_by).and_raise(ActiveRecord::RecordNotFound)
+
+      delete :destroy, params: { id: 1 }
+
+      expect(response).to redirect_to(operator_cat_in_path)
+    end
+  end
+end

--- a/spec/controllers/operator/operator_sessions_controller_spec.rb
+++ b/spec/controllers/operator/operator_sessions_controller_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operator::OperatorSessionsController, type: :controller do
+  describe 'GET #new' do
+    it 'redirects an already signed-in operator to the operates page' do
+      operator = create(:operator)
+      session[:operator_id] = operator.id
+
+      get :new
+
+      expect(response).to redirect_to(operator_operates_path)
+    end
+  end
+end

--- a/spec/controllers/operator/webhooks_controller_spec.rb
+++ b/spec/controllers/operator/webhooks_controller_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The callback route lives at a secret path derived from encrypted credentials
+# (unavailable without the master key), so this is a controller spec with an
+# explicitly drawn route rather than a request spec.
+RSpec.describe Operator::WebhooksController, type: :controller do
+  let(:validator) { instance_double(Webhooks::SignatureValidator) }
+  let(:adapter) { instance_double(Line::SdkV2Adapter) }
+  let(:processor) { instance_double(Line::EventProcessor) }
+  let(:body) { '{"events":[]}' }
+
+  # `routes.draw` mutates the global application route set, so restore the real
+  # routes afterwards to avoid breaking other specs.
+  after { Rails.application.reload_routes! }
+
+  before do
+    routes.draw { post 'callback' => 'operator/webhooks#callback' }
+    allow(Webhooks::SignatureValidator).to receive(:new).and_return(validator)
+    allow(Line::ClientProvider).to receive(:client).and_return(adapter)
+    allow(Line::EventProcessor).to receive(:new).and_return(processor)
+    allow(PrometheusMetrics).to receive(:track_webhook_request)
+  end
+
+  context 'when the signature header is missing' do
+    it 'returns bad_request without validating' do
+      post :callback, body: body
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context 'when the signature is invalid' do
+    it 'returns bad_request' do
+      allow(validator).to receive(:valid?).and_return(false)
+      request.headers['X-Line-Signature'] = 'invalid-signature'
+
+      post :callback, body: body
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context 'when the signature is valid' do
+    before do
+      allow(validator).to receive(:valid?).and_return(true)
+      allow(adapter).to receive(:parse_events).with(body).and_return([])
+      request.headers['X-Line-Signature'] = 'valid-signature'
+    end
+
+    it 'processes the events and returns ok' do
+      allow(processor).to receive(:process)
+
+      post :callback, body: body
+
+      expect(response).to have_http_status(:ok)
+      expect(processor).to have_received(:process).with([])
+      expect(PrometheusMetrics).to have_received(:track_webhook_request).with('success')
+    end
+
+    it 'returns service_unavailable and tracks a timeout on Timeout::Error' do
+      allow(processor).to receive(:process).and_raise(Timeout::Error)
+
+      post :callback, body: body
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(PrometheusMetrics).to have_received(:track_webhook_request).with('timeout')
+    end
+
+    it 'returns service_unavailable and logs a sanitized error on StandardError' do
+      allow(processor).to receive(:process).and_raise(StandardError.new('channel_secret: super-secret-token'))
+      allow(Rails.logger).to receive(:error)
+
+      post :callback, body: body
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(PrometheusMetrics).to have_received(:track_webhook_request).with('error')
+      expect(Rails.logger).to have_received(:error).with(/Webhook processing failed: \[REDACTED\]/)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  it 'is defined as a module' do
+    expect(described_class).to be_a(Module)
+  end
+end

--- a/spec/jobs/line/welcome_message_job_spec.rb
+++ b/spec/jobs/line/welcome_message_job_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe Line::WelcomeMessageJob, type: :job do
     expect(adapter).to have_received(:push_message).with('GROUP1', message)
     expect(PrometheusMetrics).to have_received(:track_message_send).with('success')
   end
+
+  context 'when pushing the message fails' do
+    before do
+      allow(adapter).to receive(:push_message).and_raise(StandardError.new('LINE API down'))
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it 'logs the error, tracks failure and re-raises' do
+      expect { described_class.perform_now('GROUP1', message) }.to raise_error(StandardError, 'LINE API down')
+
+      expect(Rails.logger).to have_received(:error).with(/WelcomeMessageJob failed for GROUP1: LINE API down/)
+      expect(PrometheusMetrics).to have_received(:track_message_send).with('error')
+    end
+  end
 end

--- a/spec/mailers/line_mailer_spec.rb
+++ b/spec/mailers/line_mailer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LineMailer, type: :mailer do
+  before do
+    # ApplicationMailer resolves the recipient from credentials, which are not
+    # decryptable without the master key. Stub only the operator entry so the
+    # rest of the credentials object stays intact for view/URL rendering.
+    allow(Rails.application.credentials).to receive(:operator).and_return(email: 'operator@example.com')
+  end
+
+  describe '#error_email' do
+    let(:mail) { described_class.error_email('GROUP123', 'Something failed') }
+
+    it 'sets the subject' do
+      expect(mail.subject).to eq('【Error通知】LINEとの通信において')
+    end
+
+    it 'delivers to the operator address from credentials' do
+      expect(mail.to).to eq(['operator@example.com'])
+    end
+
+    it 'sends from the default address' do
+      expect(mail.from).to eq(['from@example.com'])
+    end
+
+    it 'includes the group id in the body' do
+      expect(mail.text_part.decoded).to include('GROUP123')
+      expect(mail.html_part.decoded).to include('GROUP123')
+    end
+
+    it 'includes the error message in the body' do
+      expect(mail.text_part.decoded).to include('Something failed')
+      expect(mail.html_part.decoded).to include('Something failed')
+    end
+  end
+end

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionMailer, type: :mailer do
+  before do
+    # ApplicationMailer resolves the recipient from credentials, which are not
+    # decryptable without the master key. Stub only the operator entry so the
+    # rest of the credentials object stays intact for view/URL rendering.
+    allow(Rails.application.credentials).to receive(:operator).and_return(email: 'operator@example.com')
+  end
+
+  describe '#notice' do
+    let(:operator) { create(:operator, :locked, name: 'Locked Operator') }
+    let(:mail) { described_class.notice(operator, '203.0.113.5') }
+
+    it 'sets the subject' do
+      expect(mail.subject).to eq('【Warning】ロック状態のアカウントにアクセスがありました')
+    end
+
+    it 'delivers to the operator address from credentials' do
+      expect(mail.to).to eq(['operator@example.com'])
+    end
+
+    it 'includes the operator name in the body' do
+      expect(mail.text_part.decoded).to include('Locked Operator')
+      expect(mail.html_part.decoded).to include('Locked Operator')
+    end
+
+    it 'includes the access IP in the body' do
+      expect(mail.text_part.decoded).to include('203.0.113.5')
+      expect(mail.html_part.decoded).to include('203.0.113.5')
+    end
+  end
+end

--- a/spec/middleware/request_correlation_spec.rb
+++ b/spec/middleware/request_correlation_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RequestCorrelation do
+  let(:downstream_response) { [200, { 'Content-Type' => 'text/plain' }, ['OK']] }
+  let(:app) { ->(_env) { downstream_response } }
+  let(:middleware) { described_class.new(app) }
+
+  after { RequestStore.clear! }
+
+  context 'when the X-Request-ID header is present' do
+    it 'uses the header value as the request_id' do
+      captured = {}
+      app = lambda do |_env|
+        captured[:request_id] = RequestStore.store[:request_id]
+        captured[:correlation_id] = RequestStore.store[:correlation_id]
+        downstream_response
+      end
+
+      described_class.new(app).call('HTTP_X_REQUEST_ID' => 'abc-123')
+
+      expect(captured[:request_id]).to eq('abc-123')
+      expect(captured[:correlation_id]).to eq('abc-123')
+    end
+  end
+
+  context 'when the X-Request-ID header is absent' do
+    it 'generates a UUID as the request_id' do
+      allow(SecureRandom).to receive(:uuid).and_return('generated-uuid')
+      captured = {}
+      app = lambda do |_env|
+        captured[:request_id] = RequestStore.store[:request_id]
+        downstream_response
+      end
+
+      described_class.new(app).call({})
+
+      expect(captured[:request_id]).to eq('generated-uuid')
+    end
+  end
+
+  it 'returns the downstream response' do
+    expect(middleware.call({})).to eq(downstream_response)
+  end
+
+  it 'clears RequestStore after the request to prevent leakage' do
+    middleware.call('HTTP_X_REQUEST_ID' => 'abc-123')
+
+    expect(RequestStore.store[:request_id]).to be_nil
+  end
+
+  it 'clears RequestStore even when the downstream app raises' do
+    failing_app = ->(_env) { raise 'boom' }
+
+    expect { described_class.new(failing_app).call({}) }.to raise_error('boom')
+    expect(RequestStore.store[:request_id]).to be_nil
+  end
+end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metric, type: :model do
+  describe '.aggregate' do
+    it 'returns aggregated statistics for matching metrics' do
+      described_class.create!(name: 'cache_hit', value: 10)
+      described_class.create!(name: 'cache_hit', value: 30)
+
+      result = described_class.aggregate('cache_hit')
+
+      expect(result[:count]).to eq(2)
+      expect(result[:total].to_f).to eq(40.0)
+      expect(result[:average].to_f).to eq(20.0)
+      expect(result[:minimum].to_f).to eq(10.0)
+      expect(result[:maximum].to_f).to eq(30.0)
+    end
+
+    it 'returns an empty hash when the aggregate query yields no row' do
+      # The aggregate query normally returns a row even with no matches, so the
+      # nil-guard is only reachable by forcing `take` to return nil.
+      relation = instance_double(ActiveRecord::Relation, take: nil)
+      scoped = instance_double(ActiveRecord::Relation, select: relation)
+      allow(described_class).to receive(:by_name).with('missing').and_return(scoped)
+
+      expect(described_class.aggregate('missing')).to eq({})
+    end
+  end
+end

--- a/spec/models/scheduler_spec.rb
+++ b/spec/models/scheduler_spec.rb
@@ -68,5 +68,86 @@ RSpec.describe Scheduler, type: :model do
       expect(LineMailer).to have_received(:error_email).with(group.line_group_id, /コンテンツ未登録/)
       expect(PrometheusMetrics).to have_received(:track_message_send).with('error')
     end
+
+    context 'when a group is processed successfully' do
+      let(:group) { create(:line_group, status: :wait) }
+
+      before do
+        allow(Rails.application).to receive(:credentials).and_return(
+          double(operator: { email: 'test@example.com' })
+        )
+        allow(sampler).to receive_messages(available?: true, sample: double(body: 'message body'))
+        allow(Line::ReminderJob).to receive(:perform_later)
+        allow(PrometheusMetrics).to receive(:track_message_send)
+      end
+
+      it 'moves the group to call status and enqueues a reminder job' do
+        described_class.scheduler(LineGroup.where(id: group.id), sampler, :wait)
+
+        expect(group.reload.status).to eq('call')
+        expect(Line::ReminderJob).to have_received(:perform_later)
+          .with(group.line_group_id, kind_of(Array))
+      end
+    end
+  end
+
+  describe '.call_notice' do
+    it 'schedules call reminders for groups due for a call' do
+      allow(LineGroup).to receive(:remind_call).and_return(:remind_groups)
+      allow(described_class).to receive(:initialize_alarm_sampler).and_return(:sampler)
+      allow(described_class).to receive(:scheduler)
+
+      described_class.call_notice
+
+      expect(described_class).to have_received(:scheduler).with(:remind_groups, :sampler, :call)
+    end
+  end
+
+  describe '.wait_notice' do
+    it 'schedules wait reminders for groups due for a wait' do
+      allow(LineGroup).to receive(:remind_wait).and_return(:remind_groups)
+      allow(described_class).to receive(:initialize_content_sampler).and_return(:sampler)
+      allow(described_class).to receive(:scheduler)
+
+      described_class.wait_notice
+
+      expect(described_class).to have_received(:scheduler).with(:remind_groups, :sampler, :wait)
+    end
+  end
+
+  describe '.initialize_alarm_sampler' do
+    it 'preloads and returns an alarm content sampler' do
+      sampler = instance_double(Line::AlarmContentSampler)
+      allow(Line::AlarmContentSampler).to receive(:new).and_return(sampler)
+      allow(sampler).to receive(:preload_all)
+
+      expect(described_class.initialize_alarm_sampler).to eq(sampler)
+      expect(sampler).to have_received(:preload_all)
+    end
+  end
+
+  describe '.initialize_content_sampler' do
+    it 'preloads and returns a content sampler' do
+      sampler = instance_double(Line::ContentSampler)
+      allow(Line::ContentSampler).to receive(:new).and_return(sampler)
+      allow(sampler).to receive(:preload_all)
+
+      expect(described_class.initialize_content_sampler).to eq(sampler)
+      expect(sampler).to have_received(:preload_all)
+    end
+  end
+
+  describe '.build_messages' do
+    it 'builds call messages for the :call notice type' do
+      sampler = instance_double(Line::AlarmContentSampler)
+      allow(sampler).to receive_messages(available?: true, sample: double(body: 'x'))
+
+      expect(described_class.build_messages(sampler, :call).size).to eq(2)
+    end
+
+    it 'raises ArgumentError for an unknown notice type' do
+      expect { described_class.build_messages(double, :unknown) }
+        .to raise_error(ArgumentError, 'Unknown notice type: unknown')
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,33 @@
+# SimpleCov must start before any application code is loaded so that every file
+# (including those evaluated during boot) is tracked accurately.
+if ENV['CI'] == 'true' || ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+  require 'simplecov-console'
+
+  SimpleCov.start 'rails' do
+    # Measure branch coverage in addition to line coverage
+    enable_coverage :branch
+
+    # Set minimum coverage threshold (line and branch)
+    minimum_coverage line: 100, branch: 100
+
+    # Filters - exclude these directories from coverage
+    add_filter '/spec/'
+    add_filter '/config/'
+    add_filter '/vendor/'
+    add_filter '/test/'
+
+    # Coverage output formatters
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+                                                         SimpleCov::Formatter::HTMLFormatter,
+                                                         SimpleCov::Formatter::Console
+                                                       ])
+
+    # Track files even if they are not loaded
+    track_files '{app,lib}/**/*.rb'
+  end
+end
+
 require 'spec_helper'
 ENV['RAILS_ENV'] = 'test' # Force test environment
 require_relative '../config/environment'
@@ -17,32 +47,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
-end
-
-# SimpleCov configuration
-if ENV['CI'] == 'true' || ENV['COVERAGE'] == 'true'
-  require 'simplecov'
-  require 'simplecov-console'
-
-  SimpleCov.start 'rails' do
-    # Set minimum coverage threshold
-    minimum_coverage 75
-
-    # Filters - exclude these directories from coverage
-    add_filter '/spec/'
-    add_filter '/config/'
-    add_filter '/vendor/'
-    add_filter '/test/'
-
-    # Coverage output formatters
-    formatter SimpleCov::Formatter::MultiFormatter.new([
-                                                         SimpleCov::Formatter::HTMLFormatter,
-                                                         SimpleCov::Formatter::Console
-                                                       ])
-
-    # Track files even if they are not loaded
-    track_files '{app,lib}/**/*.rb'
-  end
 end
 
 # Load support files

--- a/spec/requests/api/pwa/configs_defaults_spec.rb
+++ b/spec/requests/api/pwa/configs_defaults_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the default_network_config / default_features fallbacks, used only when
+# the pwa_config file omits those keys.
+RSpec.describe 'Api::Pwa::Configs defaults', type: :request do
+  it 'falls back to default network and feature config when the config omits them' do
+    allow(Rails.application).to receive(:config_for).and_call_original
+    allow(Rails.application).to receive(:config_for).with(:pwa_config).and_return({})
+
+    get '/api/pwa/config'
+
+    json = JSON.parse(response.body)
+    expect(json['network']).to eq('timeout' => 3000, 'retries' => 1)
+    expect(json['features']).to eq(
+      'install_prompt' => true, 'push_notifications' => false, 'background_sync' => false
+    )
+  end
+end

--- a/spec/requests/prometheus_metrics_endpoint_spec.rb
+++ b/spec/requests/prometheus_metrics_endpoint_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /metrics', type: :request do
+  def basic_auth(user, pass)
+    { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(user, pass) }
+  end
+
+  context 'in a non-production environment' do
+    it 'exposes metrics without authentication' do
+      create(:line_group)
+      get '/metrics'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include('text/plain')
+      expect(response.body).to include('line_groups_total')
+    end
+  end
+
+  context 'in production' do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+    end
+
+    context 'when monitoring credentials are not configured' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MONITOR_USERNAME').and_return(nil)
+        allow(ENV).to receive(:[]).with('MONITOR_PASSWORD').and_return(nil)
+      end
+
+      it 'returns forbidden' do
+        get '/metrics'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when monitoring credentials are configured' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('MONITOR_USERNAME').and_return('monitor')
+        allow(ENV).to receive(:[]).with('MONITOR_PASSWORD').and_return('s3cret')
+      end
+
+      it 'requires HTTP basic authentication' do
+        get '/metrics'
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'grants access with the correct credentials' do
+        get '/metrics', headers: basic_auth('monitor', 's3cret')
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'rejects an incorrect password' do
+        get '/metrics', headers: basic_auth('monitor', 'wrong')
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'rejects an incorrect username' do
+        get '/metrics', headers: basic_auth('intruder', 's3cret')
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -129,6 +129,35 @@ RSpec.describe AuthenticationService do
       end
     end
 
+    context 'when authentication fails due to a locked account' do
+      let(:locked_result) { AuthResult.failed(:account_locked, user: user) }
+
+      before do
+        allow(password_provider).to receive(:authenticate).and_return(locked_result)
+      end
+
+      it 'records the locked-account metric' do
+        expect(AUTH_LOCKED_ACCOUNTS_TOTAL).to receive(:increment).with(labels: { provider: :password })
+
+        described_class.authenticate(:password, email: 'test@example.com', password: 'secret123')
+      end
+    end
+
+    context 'when recording metrics raises' do
+      before do
+        allow(password_provider).to receive(:authenticate).and_return(AuthResult.success(user: user))
+        allow(AUTH_ATTEMPTS_TOTAL).to receive(:increment).and_raise(StandardError.new('prometheus down'))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'logs the failure and does not break authentication' do
+        result = described_class.authenticate(:password, email: 'test@example.com', password: 'secret123')
+
+        expect(result.success?).to be true
+        expect(Rails.logger).to have_received(:error).with(/Failed to record authentication metrics/)
+      end
+    end
+
     context 'when MFA is pending' do
       let(:pending_result) { AuthResult.pending_mfa(user: user) }
 

--- a/spec/services/data_migration_validator_spec.rb
+++ b/spec/services/data_migration_validator_spec.rb
@@ -2,187 +2,124 @@
 
 require 'rails_helper'
 
-# NOTE: These tests are for the migration tool that was used to migrate from Sorcery to Rails 8 authentication.
-# Since the migration is complete and crypted_password column has been removed, these tests are now skipped.
-RSpec.describe DataMigrationValidator, skip: 'Migration complete - crypted_password column removed' do
+# The Operator table no longer has the legacy `crypted_password` column, so these
+# specs drive the validator through doubles/stubs instead of real ActiveRecord
+# queries. This keeps the migration tooling covered without depending on a schema
+# that has since been removed.
+RSpec.describe DataMigrationValidator do
   describe '.generate_checksum' do
-    before do
-      # Clean up any existing operators to prevent email uniqueness conflicts
-      Operator.delete_all
+    let(:model_class) do
+      instance_double(ActiveRecord::Relation).tap do |model|
+        allow(model).to receive(:pluck)
+          .with(:id, :email, :crypted_password, :password_digest)
+          .and_return(records)
+      end
     end
 
-    let!(:operator1) do
-      Operator.create!(
-        name: 'Test User 1',
-        email: 'test1@example.com',
-        password: 'password123',
-        password_confirmation: 'password123',
-        role: :operator
-      )
+    let(:records) do
+      [
+        [1, 'a@example.com', nil, 'digest1'],
+        [2, 'b@example.com', nil, 'digest2']
+      ]
     end
 
-    let!(:operator2) do
-      Operator.create!(
-        name: 'Test User 2',
-        email: 'test2@example.com',
-        password: 'password456',
-        password_confirmation: 'password456',
-        role: :operator
-      )
+    it 'returns one checksum per record' do
+      expect(described_class.generate_checksum(model_class).size).to eq(2)
     end
 
-    it 'generates checksums for all records' do
-      checksums = described_class.generate_checksum(Operator)
-
-      expect(checksums).to be_an(Array)
-      expect(checksums.size).to eq(2)
+    it 'returns SHA256 hex digests' do
+      expect(described_class.generate_checksum(model_class)).to all(match(/\A[a-f0-9]{64}\z/))
     end
 
-    it 'generates SHA256 checksums' do
-      checksums = described_class.generate_checksum(Operator)
-
-      expect(checksums).to all(match(/\A[a-f0-9]{64}\z/))
+    it 'is deterministic for identical data' do
+      first = described_class.generate_checksum(model_class)
+      second = described_class.generate_checksum(model_class)
+      expect(first).to eq(second)
     end
 
-    it 'generates consistent checksums for same data' do
-      checksums1 = described_class.generate_checksum(Operator)
-      checksums2 = described_class.generate_checksum(Operator)
+    it 'produces different checksums when the underlying data differs' do
+      other = instance_double(ActiveRecord::Relation)
+      allow(other).to receive(:pluck)
+        .with(:id, :email, :crypted_password, :password_digest)
+        .and_return([[1, 'a@example.com', nil, 'CHANGED']])
 
-      expect(checksums1).to eq(checksums2)
-    end
-
-    it 'generates different checksums when data changes' do
-      checksums_before = described_class.generate_checksum(Operator)
-
-      operator1.update!(crypted_password: 'new_password_hash')
-
-      checksums_after = described_class.generate_checksum(Operator)
-
-      expect(checksums_before).not_to eq(checksums_after)
+      expect(described_class.generate_checksum(model_class))
+        .not_to eq(described_class.generate_checksum(other))
     end
   end
 
   describe '.validate_migration' do
-    let(:checksums1) { %w[abc123 def456 ghi789] }
-    let(:checksums2) { %w[abc123 def456 ghi789] }
+    let(:before_checksums) { %w[abc123 def456 ghi789] }
 
-    context 'when checksums match' do
-      it 'returns true' do
-        result = described_class.validate_migration(checksums1, checksums2)
-
-        expect(result).to be true
-      end
+    it 'returns true when checksums are identical' do
+      expect(described_class.validate_migration(before_checksums, before_checksums.dup)).to be true
     end
 
-    context 'when records are lost' do
-      let(:checksums_after) { %w[abc123 def456] }
-
-      it 'raises error with missing count' do
-        expect { described_class.validate_migration(checksums1, checksums_after) }
-          .to raise_error(RuntimeError, 'Migration validation failed: 1 records lost')
-      end
+    it 'returns true when the order changes but the data is the same' do
+      expect(described_class.validate_migration(before_checksums, %w[ghi789 abc123 def456])).to be true
     end
 
-    context 'when unexpected records are added' do
-      let(:checksums_after) { %w[abc123 def456 ghi789 jkl012] }
-
-      it 'raises error with added count' do
-        expect { described_class.validate_migration(checksums1, checksums_after) }
-          .to raise_error(RuntimeError, 'Migration validation failed: 1 unexpected records added')
-      end
+    it 'raises when records are lost' do
+      expect { described_class.validate_migration(before_checksums, %w[abc123 def456]) }
+        .to raise_error(RuntimeError, 'Migration validation failed: 1 records lost')
     end
 
-    context 'when records are modified' do
-      let(:checksums_after) { %w[abc123 def456 xyz999] }
-
-      it 'raises error about modified records' do
-        expect { described_class.validate_migration(checksums1, checksums_after) }
-          .to raise_error(RuntimeError, /Migration validation failed: \d+ records modified or corrupted/)
-      end
+    it 'raises when unexpected records are added' do
+      expect { described_class.validate_migration(before_checksums, %w[abc123 def456 ghi789 jkl012]) }
+        .to raise_error(RuntimeError, 'Migration validation failed: 1 unexpected records added')
     end
 
-    context 'when order changes but data is same' do
-      let(:checksums_after) { %w[ghi789 abc123 def456] }
-
-      it 'returns true' do
-        result = described_class.validate_migration(checksums1, checksums_after)
-
-        expect(result).to be true
-      end
+    it 'raises when records are modified but the count is unchanged' do
+      expect { described_class.validate_migration(before_checksums, %w[abc123 def456 xyz999]) }
+        .to raise_error(RuntimeError, /Migration validation failed: \d+ records modified or corrupted/)
     end
   end
 
   describe '.verify_integrity' do
+    let(:model_class) { class_double(Operator) }
+    let(:missing_relation) { instance_double(ActiveRecord::Relation, count: missing_auth) }
+    let(:duplicate_relation) { instance_double(ActiveRecord::Relation, count: duplicate_auth) }
+
     before do
-      # Clean up any existing operators to prevent email uniqueness conflicts
-      Operator.delete_all
+      allow(model_class).to receive(:count).and_return(total)
+      allow(model_class).to receive(:where)
+        .with('crypted_password IS NULL AND password_digest IS NULL')
+        .and_return(missing_relation)
+      allow(model_class).to receive(:where)
+        .with('crypted_password IS NOT NULL AND password_digest IS NOT NULL')
+        .and_return(duplicate_relation)
     end
 
-    context 'when all records have valid authentication data' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
+    context 'when there are no integrity issues' do
+      let(:total) { 5 }
+      let(:missing_auth) { 0 }
+      let(:duplicate_auth) { 0 }
 
-      it 'returns valid result' do
-        result = described_class.verify_integrity(Operator)
-
-        expect(result[:valid]).to be true
-        expect(result[:total_records]).to eq(1)
-        expect(result[:issues]).to be_empty
+      it 'reports a valid result' do
+        result = described_class.verify_integrity(model_class)
+        expect(result).to eq(valid: true, total_records: 5, issues: [])
       end
     end
 
-    context 'when records have missing authentication data' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
+    context 'when records are missing authentication data' do
+      let(:total) { 3 }
+      let(:missing_auth) { 2 }
+      let(:duplicate_auth) { 0 }
 
-      before do
-        operator.update!(crypted_password: nil, password_digest: nil)
-      end
-
-      it 'reports missing authentication data' do
-        result = described_class.verify_integrity(Operator)
-
+      it 'reports the missing authentication data issue' do
+        result = described_class.verify_integrity(model_class)
         expect(result[:valid]).to be false
-        expect(result[:issues]).to include('1 records missing authentication data')
+        expect(result[:issues]).to include('2 records missing authentication data')
       end
     end
 
-    context 'when records have duplicate authentication methods' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
+    context 'when records have both authentication methods' do
+      let(:total) { 3 }
+      let(:missing_auth) { 0 }
+      let(:duplicate_auth) { 1 }
 
-      before do
-        # Simulate having both authentication methods
-        operator.update!(
-          crypted_password: 'old_password_hash',
-          password_digest: operator.crypted_password
-        )
-      end
-
-      it 'reports duplicate authentication methods' do
-        result = described_class.verify_integrity(Operator)
-
+      it 'reports the duplicate authentication issue' do
+        result = described_class.verify_integrity(model_class)
         expect(result[:valid]).to be false
         expect(result[:issues]).to include('1 records have both crypted_password and password_digest')
       end
@@ -190,82 +127,30 @@ RSpec.describe DataMigrationValidator, skip: 'Migration complete - crypted_passw
   end
 
   describe '.validate_password_migration' do
+    let(:scoped) { instance_double(ActiveRecord::Relation) }
+    let(:where_chain) { instance_double(ActiveRecord::QueryMethods::WhereChain) }
+    let(:not_migrated) { instance_double(ActiveRecord::Relation, count: missing) }
+
     before do
-      # Clean up any existing operators to prevent email uniqueness conflicts
-      Operator.delete_all
+      allow(Operator).to receive(:where).with(password_digest: nil).and_return(scoped)
+      allow(scoped).to receive(:where).and_return(where_chain)
+      allow(where_chain).to receive(:not).with(crypted_password: nil).and_return(not_migrated)
     end
 
-    context 'when all operators have password_digest' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
-
-      before do
-        # Simulate fully migrated state (password_digest set, crypted_password cleared)
-        operator.update!(
-          password_digest: BCrypt::Password.create('password123'),
-          crypted_password: nil
-        )
-      end
+    context 'when every operator has a password_digest' do
+      let(:missing) { 0 }
 
       it 'returns true' do
-        result = described_class.validate_password_migration
-
-        expect(result).to be true
+        expect(described_class.validate_password_migration).to be true
       end
     end
 
-    context 'when operators are missing password_digest' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
+    context 'when some operators are missing a password_digest' do
+      let(:missing) { 2 }
 
-      before do
-        # Simulate old Sorcery format (crypted_password only)
-        operator.update!(
-          crypted_password: 'old_password_hash',
-          password_digest: nil
-        )
-      end
-
-      it 'raises error with missing count' do
+      it 'raises with the missing count' do
         expect { described_class.validate_password_migration }
-          .to raise_error(RuntimeError, 'Migration incomplete: 1 operators missing password_digest')
-      end
-    end
-
-    context 'when operators only have password_digest' do
-      let!(:operator) do
-        Operator.create!(
-          name: 'Test User',
-          email: 'test@example.com',
-          password: 'password123',
-          password_confirmation: 'password123',
-          role: :operator
-        )
-      end
-
-      before do
-        # Simulate fully migrated state (password_digest only)
-        operator.update!(crypted_password: nil)
-      end
-
-      it 'returns true' do
-        result = described_class.validate_password_migration
-
-        expect(result).to be true
+          .to raise_error(RuntimeError, 'Migration incomplete: 2 operators missing password_digest')
       end
     end
   end

--- a/spec/services/line/client_adapter_spec.rb
+++ b/spec/services/line/client_adapter_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe Line::SdkV2Adapter do
       expect(Line::Bot::Client).to have_received(:new)
     end
 
+    it 'passes each credential to the client config block' do
+      config = double('config')
+      allow(config).to receive(:channel_id=)
+      allow(config).to receive(:channel_secret=)
+      allow(config).to receive(:channel_token=)
+      allow(Line::Bot::Client).to receive(:new).and_yield(config).and_return(mock_client)
+
+      described_class.new(credentials)
+
+      expect(config).to have_received(:channel_id=).with('test_channel_id')
+      expect(config).to have_received(:channel_secret=).with('test_channel_secret')
+      expect(config).to have_received(:channel_token=).with('test_channel_token')
+    end
+
     it 'raises ArgumentError when channel_id is missing' do
       invalid_credentials = credentials.except(:channel_id)
 

--- a/spec/services/line/command_handler_branch_coverage_spec.rb
+++ b/spec/services/line/command_handler_branch_coverage_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Supplements command_handler_spec.rb with the remaining conditional branches.
+RSpec.describe Line::CommandHandler do
+  let(:adapter) { instance_double(Line::ClientAdapter) }
+  let(:handler) { described_class.new(adapter) }
+  let(:group_id) { 'GROUP123' }
+
+  describe '#handle_removal (branch coverage)' do
+    it 'does nothing when the message is not the removal command' do
+      event = double('event', message: double(text: 'just chatting'))
+
+      expect { handler.handle_removal(event, group_id) }.not_to raise_error
+    end
+
+    it 'does nothing when the event has no message' do
+      event = double('event', message: nil)
+
+      expect { handler.handle_removal(event, group_id) }.not_to raise_error
+    end
+
+    it 'leaves the group when the source is a group' do
+      allow(adapter).to receive(:leave_group)
+      event = double('event',
+                     message: double(text: described_class::REMOVAL_COMMAND),
+                     source: double(group_id: group_id, room_id: nil))
+
+      handler.handle_removal(event, group_id)
+
+      expect(adapter).to have_received(:leave_group).with(group_id)
+    end
+
+    it 'leaves the room when the source is a room' do
+      allow(adapter).to receive(:leave_room)
+      event = double('event',
+                     message: double(text: described_class::REMOVAL_COMMAND),
+                     source: double(group_id: nil, room_id: 'ROOM123'))
+
+      handler.handle_removal(event, group_id)
+
+      expect(adapter).to have_received(:leave_room).with(group_id)
+    end
+
+    it 'does nothing when the source is neither a group nor a room' do
+      event = double('event',
+                     message: double(text: described_class::REMOVAL_COMMAND),
+                     source: double(group_id: nil, room_id: nil))
+
+      expect { handler.handle_removal(event, group_id) }.not_to raise_error
+    end
+
+    it 'does nothing when the removal command has no source' do
+      event = double('event',
+                     message: double(text: described_class::REMOVAL_COMMAND),
+                     source: nil)
+
+      expect { handler.handle_removal(event, group_id) }.not_to raise_error
+    end
+  end
+
+  describe '#handle_span_setting (branch coverage)' do
+    it 'returns early when the message has no text' do
+      event = double('event', message: nil)
+
+      expect { handler.handle_span_setting(event, group_id) }.not_to raise_error
+    end
+
+    it 'returns early when the group is not found' do
+      event = double('event', message: double(text: described_class::SPAN_FASTER))
+
+      expect { handler.handle_span_setting(event, 'UNKNOWN') }.not_to raise_error
+    end
+
+    it 'sends a confirmation even when the text matches no case clause' do
+      # `span_command?` is stubbed true so the `case` falls through its whens,
+      # exercising the implicit else branch.
+      create(:line_group, line_group_id: group_id)
+      allow(handler).to receive(:span_command?).and_return(true)
+      allow(adapter).to receive(:push_message)
+      event = double('event', message: double(text: 'UNMAPPED COMMAND'))
+
+      handler.handle_span_setting(event, group_id)
+
+      expect(adapter).to have_received(:push_message).with(group_id, hash_including(type: 'text'))
+    end
+  end
+end

--- a/spec/services/line/event_processor_branch_coverage_spec.rb
+++ b/spec/services/line/event_processor_branch_coverage_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Supplements event_processor_spec.rb with the remaining conditional branches:
+# an unknown event type, a nil event source, and processed-set trimming.
+RSpec.describe Line::EventProcessor do
+  let(:adapter) { instance_double(Line::ClientAdapter) }
+  let(:member_counter) { instance_double(Line::MemberCounter) }
+  let(:group_service) { instance_double(Line::GroupService) }
+  let(:command_handler) { instance_double(Line::CommandHandler) }
+  let(:one_on_one_handler) { instance_double(Line::OneOnOneHandler) }
+
+  let(:processor) do
+    described_class.new(
+      adapter: adapter,
+      member_counter: member_counter,
+      group_service: group_service,
+      command_handler: command_handler,
+      one_on_one_handler: one_on_one_handler
+    )
+  end
+
+  before do
+    stub_line_credentials
+    stub_const('Line::Bot::Event::Message', Class.new)
+    stub_const('Line::Bot::Event::Join', Class.new)
+    stub_const('Line::Bot::Event::Leave', Class.new)
+    stub_const('Line::Bot::Event::MemberJoined', Class.new)
+    stub_const('Line::Bot::Event::MemberLeft', Class.new)
+
+    allow(member_counter).to receive(:count).and_return(3)
+    allow(PrometheusMetrics).to receive(:track_webhook_duration)
+    allow(PrometheusMetrics).to receive(:track_event_success)
+  end
+
+  def none_match(event)
+    [Line::Bot::Event::Message, Line::Bot::Event::Join, Line::Bot::Event::MemberJoined,
+     Line::Bot::Event::Leave, Line::Bot::Event::MemberLeft].each do |klass|
+      allow(klass).to receive(:===).with(event).and_return(false)
+    end
+  end
+
+  it 'processes an unknown event type with a nil source without dispatching to a handler' do
+    unknown_event = double('Unknown Event', class: Object, timestamp: 12_345, source: nil, message: nil)
+    none_match(unknown_event)
+
+    expect { processor.process([unknown_event]) }.not_to raise_error
+
+    expect(PrometheusMetrics).to have_received(:track_event_success).with(unknown_event)
+  end
+
+  it 'trims the processed-events set once it exceeds the size limit' do
+    message_event = double('Message Event', class: Line::Bot::Event::Message, timestamp: 999,
+                                            source: double(group_id: 'GROUP123', room_id: nil),
+                                            message: double(id: 'MSG1', text: 'hi'))
+    allow(Line::Bot::Event::Message).to receive(:===).with(message_event).and_return(true)
+    [Line::Bot::Event::Join, Line::Bot::Event::MemberJoined, Line::Bot::Event::Leave,
+     Line::Bot::Event::MemberLeft].each do |klass|
+      allow(klass).to receive(:===).with(message_event).and_return(false)
+    end
+    allow(command_handler).to receive(:handle_removal)
+    allow(command_handler).to receive(:handle_span_setting)
+    allow(group_service).to receive(:update_record)
+
+    oversized = Set.new((0..10_000).map(&:to_s))
+    processor.instance_variable_set(:@processed_events, oversized)
+
+    processor.process([message_event])
+
+    expect(oversized).not_to include('0') # first element was evicted
+    expect(group_service).to have_received(:update_record).with('GROUP123', 3)
+  end
+end

--- a/spec/services/line/group_service_branch_coverage_spec.rb
+++ b/spec/services/line/group_service_branch_coverage_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Supplements group_service_spec.rb with the remaining branch.
+RSpec.describe Line::GroupService do
+  let(:adapter) { instance_double(Line::ClientAdapter) }
+  let(:service) { described_class.new(adapter) }
+
+  describe '#send_welcome_message' do
+    it 'enqueues a nil message when the message type is unknown' do
+      allow(Line::WelcomeMessageJob).to receive(:perform_later)
+
+      service.send_welcome_message('GROUP123', message_type: :unexpected)
+
+      expect(Line::WelcomeMessageJob).to have_received(:perform_later).with('GROUP123', nil)
+    end
+  end
+end

--- a/spec/services/line/samplers_available_spec.rb
+++ b/spec/services/line/samplers_available_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the #available? branches for both content samplers.
+RSpec.describe Line::ContentSampler do
+  let(:sampler) { described_class.new }
+
+  describe '#available?' do
+    it 'returns true when content exists and reuses the cache on subsequent calls' do
+      create(:content, category: :free)
+
+      expect(sampler.available?(:free)).to be true # cache miss -> refresh
+      expect(sampler.available?(:free)).to be true # cache hit -> skip refresh
+    end
+
+    it 'returns false when no content exists for the category' do
+      expect(sampler.available?(:text)).to be false
+    end
+  end
+end
+
+RSpec.describe Line::AlarmContentSampler do
+  let(:sampler) { described_class.new }
+
+  describe '#available?' do
+    it 'returns true when alarm content exists and reuses the cache on subsequent calls' do
+      create(:alarm_content, category: :contact)
+
+      expect(sampler.available?(:contact)).to be true
+      expect(sampler.available?(:contact)).to be true
+    end
+
+    it 'returns false when no alarm content exists for the category' do
+      expect(sampler.available?(:text)).to be false
+    end
+  end
+end

--- a/spec/services/prometheus_metrics_spec.rb
+++ b/spec/services/prometheus_metrics_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PrometheusMetrics do
+  # Each tracking method is guarded by `return unless defined?(METRIC_CONSTANT)`.
+  # The metric constants are defined globally in config/initializers/prometheus.rb,
+  # so the "defined" branch runs in the normal test environment. `hide_const`
+  # exercises the early-return branch when the constant is undefined.
+
+  let(:event) { double('LineEvent') }
+
+  describe '.track_webhook_duration' do
+    it 'observes the duration when the metric is defined' do
+      expect(WEBHOOK_DURATION).to receive(:observe).with(1.5, labels: { event_type: 'message' })
+
+      described_class.track_webhook_duration('message', 1.5)
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('WEBHOOK_DURATION')
+      expect(described_class.track_webhook_duration('message', 1.5)).to be_nil
+    end
+  end
+
+  describe '.track_webhook_request' do
+    it 'increments the counter when the metric is defined' do
+      expect(WEBHOOK_REQUESTS_TOTAL).to receive(:increment).with(labels: { status: 'success' })
+
+      described_class.track_webhook_request('success')
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('WEBHOOK_REQUESTS_TOTAL')
+      expect(described_class.track_webhook_request('success')).to be_nil
+    end
+  end
+
+  describe '.track_event_success' do
+    it 'increments the counter with success status when the metric is defined' do
+      expect(EVENT_PROCESSED_TOTAL).to receive(:increment).with(
+        labels: { event_type: event.class.name, status: 'success' }
+      )
+
+      described_class.track_event_success(event)
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('EVENT_PROCESSED_TOTAL')
+      expect(described_class.track_event_success(event)).to be_nil
+    end
+  end
+
+  describe '.track_event_failure' do
+    it 'increments the counter with error status when the metric is defined' do
+      expect(EVENT_PROCESSED_TOTAL).to receive(:increment).with(
+        labels: { event_type: event.class.name, status: 'error' }
+      )
+
+      described_class.track_event_failure(event, StandardError.new('boom'))
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('EVENT_PROCESSED_TOTAL')
+      expect(described_class.track_event_failure(event, StandardError.new('boom'))).to be_nil
+    end
+  end
+
+  describe '.track_line_api_call' do
+    it 'records the call and duration when both metrics are defined' do
+      expect(LINE_API_CALLS_TOTAL).to receive(:increment).with(labels: { method: 'push', status: '200' })
+      expect(LINE_API_DURATION).to receive(:observe).with(0.3, labels: { method: 'push' })
+
+      described_class.track_line_api_call('push', '200', 0.3)
+    end
+
+    it 'returns nil when a required metric is undefined' do
+      hide_const('LINE_API_DURATION')
+      expect(described_class.track_line_api_call('push', '200', 0.3)).to be_nil
+    end
+  end
+
+  describe '.track_message_send' do
+    it 'increments the counter when the metric is defined' do
+      expect(MESSAGE_SEND_TOTAL).to receive(:increment).with(labels: { status: 'success' })
+
+      described_class.track_message_send('success')
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('MESSAGE_SEND_TOTAL')
+      expect(described_class.track_message_send('success')).to be_nil
+    end
+  end
+
+  describe '.update_group_count' do
+    it 'sets the gauge when the metric is defined' do
+      expect(LINE_GROUPS_TOTAL).to receive(:set).with(42)
+
+      described_class.update_group_count(42)
+    end
+
+    it 'returns nil when the metric is undefined' do
+      hide_const('LINE_GROUPS_TOTAL')
+      expect(described_class.update_group_count(42)).to be_nil
+    end
+  end
+end

--- a/spec/services/resilience/retry_handler_spec.rb
+++ b/spec/services/resilience/retry_handler_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resilience::RetryHandler do
+  describe '#call' do
+    it 'returns the block result when it succeeds on the first attempt' do
+      handler = described_class.new
+      expect(handler.call { 42 }).to eq(42)
+    end
+
+    it 'retries a retryable error and returns the eventual result' do
+      handler = described_class.new(max_attempts: 3, backoff_factor: 2)
+      allow(handler).to receive(:sleep) # avoid real backoff delay
+      attempts = 0
+
+      result = handler.call do
+        attempts += 1
+        raise Net::OpenTimeout if attempts < 2
+
+        'recovered'
+      end
+
+      expect(result).to eq('recovered')
+      expect(attempts).to eq(2)
+    end
+
+    it 're-raises the error after exceeding max attempts' do
+      handler = described_class.new(max_attempts: 2, backoff_factor: 2)
+      allow(handler).to receive(:sleep)
+
+      expect { handler.call { raise Net::ReadTimeout } }.to raise_error(Net::ReadTimeout)
+    end
+
+    it 'does not retry a non-retryable error' do
+      handler = described_class.new(max_attempts: 3)
+
+      expect { handler.call { raise ArgumentError, 'nope' } }.to raise_error(ArgumentError, 'nope')
+    end
+
+    it 'retries an error that carries a 500 response' do
+      error_class = Class.new(StandardError) do
+        def response
+          Struct.new(:code).new('500')
+        end
+      end
+      handler = described_class.new(max_attempts: 2, backoff_factor: 2)
+      allow(handler).to receive(:sleep)
+      attempts = 0
+
+      result = handler.call do
+        attempts += 1
+        raise error_class if attempts < 2
+
+        'ok'
+      end
+
+      expect(result).to eq('ok')
+    end
+
+    it 'does not retry an error whose response is not a 500' do
+      error_class = Class.new(StandardError) do
+        def response
+          Struct.new(:code).new('404')
+        end
+      end
+      handler = described_class.new(max_attempts: 3)
+
+      expect { handler.call { raise error_class } }.to raise_error(error_class)
+    end
+
+    it 'does not retry an error whose response is nil' do
+      error_class = Class.new(StandardError) do
+        def response
+          nil
+        end
+      end
+      handler = described_class.new(max_attempts: 3)
+
+      expect { handler.call { raise error_class } }.to raise_error(error_class)
+    end
+  end
+end

--- a/spec/services/webhooks/signature_validator_spec.rb
+++ b/spec/services/webhooks/signature_validator_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::SignatureValidator do
+  let(:secret) { 'test-channel-secret' }
+  let(:validator) { described_class.new(secret) }
+  let(:body) { '{"events":[]}' }
+
+  def sign(body, secret)
+    Base64.strict_encode64(
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('SHA256'), secret, body)
+    )
+  end
+
+  describe '#valid?' do
+    context 'when the signature is blank' do
+      it 'returns false for nil' do
+        expect(validator.valid?(body, nil)).to be false
+      end
+
+      it 'returns false for an empty string' do
+        expect(validator.valid?(body, '')).to be false
+      end
+    end
+
+    context 'when the signature matches the computed HMAC' do
+      it 'returns true' do
+        expect(validator.valid?(body, sign(body, secret))).to be true
+      end
+    end
+
+    context 'when the signature does not match' do
+      it 'returns false' do
+        expect(validator.valid?(body, sign(body, 'wrong-secret'))).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

テストカバレッジを **行・ブランチともに 100%** へ引き上げました。

| | 変更前 | 変更後 |
|---|---|---|
| 行カバレッジ | 78.13% | **100.0%** (1080/1080) |
| ブランチカバレッジ | 75.57% | **100.0%** (237/237) |

- テスト: **810 examples / 0 failures**（6 pending は既存の PWA system spec skip）
- RuboCop: クリーン（rubocop-rspec 含む）

## テスト基盤の改善（`spec/rails_helper.rb`）

- `enable_coverage :branch` を有効化し、ブランチカバレッジを常時計測
- `SimpleCov.start` を環境ロード前へ移動し、boot 時にロードされるファイルも正確に計測
- `minimum_coverage` を line/branch ともに **100%** へ引き上げ（回帰防止）

## 潜在バグの修正（prometheus-client 4.x の API 不一致）

100% を正直に達成する過程で、テストではなく **アプリ本体の不具合** を発見・修正しました。

- `config/initializers/prometheus.rb`: `prometheus/client/formats/text` の require 漏れを追加 → **`/metrics` が常に 500 になっていた問題** を解消
- `app/services/prometheus_metrics.rb`: `observe` / `set` を 4.x 準拠の引数（`observe(value, labels:)` / `set(value)`）に修正 → `/metrics` と LINE API メトリクス収集が例外で動作していなかった問題を解消

## 主な spec の追加・変更

- これまで 0% だったファイルに spec を新規追加: health / metrics / webhooks controller、session / line mailer、request_correlation、signature_validator、prometheus_metrics、application_helper、channels
- `data_migration_validator_spec` を、削除済みの `crypted_password` カラムに依存しないよう double ベースへ書き直し（skip も解除）
- scheduler・welcome_message_job・line_groups destroy 等の未カバー経路を追加
- 既存の複雑なコードのブランチ抜けを網羅: command_handler、event_processor、group_service、content/alarm samplers、retry_handler、authentication、client_adapter、authentication_service、metric、api metrics / pwa configs、operator_sessions
- 現実には到達不能な防御的分岐（セーフナビ等）は、コメントで意図を明記のうえ内部スタブでカバー

## 備考

- 無関係な `README.md`（Qiita リンクの修正）が同一コミットに含まれています。必要なら分離してください。

## 確認方法

```bash
docker compose run --rm -e RAILS_ENV=test -e COVERAGE=true -e CI=true web \
  bash -lc "bundle exec rails assets:precompile && bundle exec rspec"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metrics compatibility and formatting, including correct label handling and group count reporting.
  * Added support for serving metrics in Prometheus text format.
  * Strengthened handling and validation of webhook, health-check, authentication, retry, and migration scenarios.

* **Tests**
  * Expanded automated coverage across controllers, services, jobs, mailers, middleware, models, APIs, and LINE integrations.
  * Added comprehensive coverage for error handling, security, monitoring, and default configuration behavior.

* **Documentation**
  * Updated the author’s Qiita profile link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->